### PR TITLE
Send deployment notifications to Data Products

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -60,8 +60,8 @@ class DataFlows extends TerraformStack {
    * @private
    */
   private getCodeDeploySnsTopic() {
-    return new SNS.DataAwsSnsTopic(this, 'backend_notifications', {
-      name: `Backend-${config.environment}-ChatBot`,
+    return new SNS.DataAwsSnsTopic(this, 'data_products_notifications', {
+      name: `DataAndLearning-${config.environment}-ChatBot`,
     });
   }
 


### PR DESCRIPTION
## Goal
Send deployment notifications to Data Products, not to the Backend team.

## Reference
Slack thread:
- https://pocket.slack.com/archives/C018HS6P3RS/p1639002755110900