### PR TITLE
Pre-review engagement: modifying field types and adding missing fields [FFRECSV2-82]

### DIFF
--- a/src/flows/prereview_engagement_feature_store_flow.py
+++ b/src/flows/prereview_engagement_feature_store_flow.py
@@ -13,6 +13,8 @@ from src.api_clients.prefect_key_value_store_client import set_kv, get_kv
 # Setting the working directory to project root makes the path start at "src"
 from src.api_clients import snowflake_client
 
+FLOW_NAME = "PreReview Engagement to Feature Group Flow1"
+FEATURE_GROUP_NAME = "prereview-engagement-metrics"
 
 @task
 def get_last_executed_value(flow_name: str, default_if_absent='2000-01-01 00:00:00') -> datetime:
@@ -81,17 +83,17 @@ def extract_from_snowflake(flow_last_executed: datetime) -> DataFrame:
                 STATUS as STATUS,
                 TYPE as TYPE,
                 RESOLVED_URL as RESOLVED_URL,
-                DAY7_SAVE_COUNT as "7_DAYS_PRIOR_CUMULATIVE_SAVE_COUNT",
-                DAY6_SAVE_COUNT as "6_DAYS_PRIOR_CUMULATIVE_SAVE_COUNT",
-                DAY5_SAVE_COUNT as "5_DAYS_PRIOR_CUMULATIVE_SAVE_COUNT",
-                DAY4_SAVE_COUNT as "4_DAYS_PRIOR_CUMULATIVE_SAVE_COUNT",
-                DAY3_SAVE_COUNT as "3_DAYS_PRIOR_CUMULATIVE_SAVE_COUNT",
-                DAY2_SAVE_COUNT as "2_DAYS_PRIOR_CUMULATIVE_SAVE_COUNT",
-                DAY1_SAVE_COUNT as "1_DAYS_PRIOR_SAVE_COUNT",
-                WEEK1_SAVE_COUNT as ALL_TIME_SAVE_COUNT,
-                WEEK1_OPEN_COUNT as ALL_TIME_OPEN_COUNT,
-                WEEK1_SHARE_COUNT as ALL_TIME_SHARE_COUNT,
-                WEEK1_FAVORITE_COUNT as ALL_TIME_FAVORITE_COUNT
+                DAY1_SAVE_COUNT as DAY1_SAVE_COUNT,
+                DAY2_SAVE_COUNT as DAY2_SAVE_COUNT,
+                DAY3_SAVE_COUNT as DAY3_SAVE_COUNT,
+                DAY4_SAVE_COUNT as DAY4_SAVE_COUNT,
+                DAY5_SAVE_COUNT as DAY5_SAVE_COUNT,
+                DAY6_SAVE_COUNT as DAY6_SAVE_COUNT,
+                DAY7_SAVE_COUNT as DAY7_SAVE_COUNT,
+                WEEK1_SAVE_COUNT as WEEK1_SAVE_COUNT,
+                WEEK1_OPEN_COUNT as WEEK1_OPEN_COUNT,
+                WEEK1_SHARE_COUNT as WEEK1_SHARE_COUNT,
+                WEEK1_FAVORITE_COUNT as WEEK1_FAVORITE_COUNT
             from analytics.dbt.pre_curated_reading_metrics
             where updated_at > %s
             ;
@@ -122,7 +124,6 @@ def dataframe_to_feature_group(dataframe: pd.DataFrame, feature_group_name: str)
     feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
     return feature_group.ingest(data_frame=dataframe, max_workers=4, max_processes=4, wait=True)
 
-FLOW_NAME = "PreReview Engagement to Feature Group Flow"
 with Flow(FLOW_NAME) as flow:
     promised_get_last_executed_flow_result = get_last_executed_value(flow_name=FLOW_NAME)
 
@@ -130,6 +131,6 @@ with Flow(FLOW_NAME) as flow:
     promised_update_last_executed_flow_result = update_last_executed_value(for_flow=FLOW_NAME)
 
     promised_extract_from_snowflake_result = extract_from_snowflake(flow_last_executed=promised_get_last_executed_flow_result)
-    promised_dataframe_to_feature_group_result = dataframe_to_feature_group(dataframe=promised_extract_from_snowflake_result, feature_group_name='new-tab-prospect-modeling-data')
+    promised_dataframe_to_feature_group_result = dataframe_to_feature_group(dataframe=promised_extract_from_snowflake_result, feature_group_name=FEATURE_GROUP_NAME)
 
 flow.run()


### PR DESCRIPTION
# Goal

- To remove the field casting on the data extraction query from Snowflake
- Adding the newly added fields from the DBT model to the  Prefect flow 
- Setting the incremental runs to use the newly added `updated_at` column from the DBT model

Note: the new fields are missing in the Feature group and needs to be created in the SageMaker for the Prefect flow changes to work
 