### PR TITLE
Fix deployment error when getting source

### DIFF
--- a/.aws/src/DataFlowsCodePipeline.ts
+++ b/.aws/src/DataFlowsCodePipeline.ts
@@ -141,7 +141,7 @@ export class DataFlowsCodePipeline extends Resource {
     const caller = this.dependencies.caller;
     // This matches the SourceOutput S3 object ARN. I believe the bucket is created by CodePipeline, but we could
     // specify one ourselves in Terraform-Modules. I couldn't find how to get this value dynamically so I'm using `-*`.
-    const sourceArtifactObjectArn = `arn:aws:s3:::pocket-codepipeline-*/${config.prefix}-CodePi/*`;
+    const sourceArtifactObjectArn = `arn:aws:s3:::pocket-codepipeline-*/${config.prefix}-*`;
 
     const dataCodebuildAssume = new iam.DataAwsIamPolicyDocument(
       this,


### PR DESCRIPTION
# Goal
Fix an error during deployment that was caused by the production CodePipeline SourceOutput being named slightly differently in prod: 'DataFlows-Prod-CodeP' in prod and 'DataFlows-Dev-CodeP**i**' in dev.