### PR TITLE
Fix environment/env name mismatch

### DIFF
--- a/.aws/src/DataFlowsCodePipeline.ts
+++ b/.aws/src/DataFlowsCodePipeline.ts
@@ -113,7 +113,7 @@ export class DataFlowsCodePipeline extends Resource {
           },
           {
             // Environment variable for deployment.
-            name: 'ENV',
+            name: 'ENVIRONMENT',
             value: config.fullEnvironment,
           },
         ],

--- a/deploy/register_flows.py
+++ b/deploy/register_flows.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     # TODO: It would be cleaner to use command line arguments instead of loading values from environment variables.
     PREFECT_PROJECT_NAME = environ['PREFECT_PROJECT_NAME']
     PREFECT_TASK_DEFINITION_ARN = environ['PREFECT_TASK_DEFINITION_ARN']
-    ENV = environ['ENV']
+    ENVIRONMENT = environ['ENVIRONMENT']
 
     FLOWS_PATH = os.path.join(environ['DATA_FLOWS_SOURCE_DIR'], 'flows/')
 
@@ -98,7 +98,7 @@ if __name__ == "__main__":
         run_config=ECSRun(
             labels=[PREFECT_PROJECT_NAME],
             task_definition_arn=PREFECT_TASK_DEFINITION_ARN,
-            env={'ENV': ENV, 'PREFECT_PROJECT_NAME': PREFECT_PROJECT_NAME},
+            env={'ENVIRONMENT': ENVIRONMENT, 'PREFECT_PROJECT_NAME': PREFECT_PROJECT_NAME},
         ),
         build=False,  # The flows are included in the Docker image, so don't need to be built by Prefect.
     ).register_all_flows(FLOWS_PATH)

--- a/src/flows/postreview_engagement_feature_store_flow.py
+++ b/src/flows/postreview_engagement_feature_store_flow.py
@@ -9,7 +9,7 @@ from utils import config
 
 # Setting variables used for the flow
 FLOW_NAME = "PostReview Engagement to Feature Group Flow"
-FEATURE_GROUP_NAME = f"{config.ENV}-postreview-enagement-aggregate-metrics-v1"
+FEATURE_GROUP_NAME = f"{config.ENVIRONMENT}-postreview-enagement-aggregate-metrics-v1"
 
 extract_sql = f"""
     select

--- a/src/flows/prereview_engagement_feature_store_flow.py
+++ b/src/flows/prereview_engagement_feature_store_flow.py
@@ -8,7 +8,7 @@ from utils import config
 
 # Setting variables used for the flow
 FLOW_NAME = "PreReview Engagement to Feature Group Flow"
-FEATURE_GROUP_NAME = f"{config.ENV}-prereview-engagement-metrics-v1"
+FEATURE_GROUP_NAME = f"{config.ENVIRONMENT}-prereview-engagement-metrics-v1"
 
 extract_sql = f"""
         select

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -5,5 +5,5 @@ ENV_DEV = "development"
 ENV_PROD = "production"
 PROJECT_LOCAL = "local"
 
-ENV = os.getenv("ENVIRONMENT", ENV_LOCAL)
+ENVIRONMENT = os.getenv("ENVIRONMENT", ENV_LOCAL)
 PREFECT_PROJECT_NAME = os.getenv('PREFECT_PROJECT_NAME', PROJECT_LOCAL)


### PR DESCRIPTION
# Goal
Fix a mismatch in the `ENV` / `ENVIRONMENT` environment variable name. We're now consistently calling it `ENVIRONMENT`.

This was causing feature store flows to fail after ~40 minutes:
> Failed to ingest some data into FeatureGroup local-postreview-enagement-aggregate-metrics-v1

https://cloud.prefect.io/pocket/task-run/94614181-f290-420c-b42b-b05d0d137ebc?logs