### PR TITLE
Cleanup NewTab engagement data during import into Snowflake [FFRECSV2-206]

### DIFF
--- a/src/flows/ff_new_tab_engagement.py
+++ b/src/flows/ff_new_tab_engagement.py
@@ -31,6 +31,8 @@ EXPORT_SQL = """
           FROM `moz-fx-data-shared-prod.activity_stream_live.impression_stats_v1`
           where date(submission_timestamp) >= date(@last_executed_timestamp)
           and submission_timestamp > @last_executed_timestamp
+          and loaded is null --don't include loaded ping
+          and array_length(tiles) >= 1 --making sure data is valid/non-empty
           qualify row_number() over (partition by document_id order by submission_timestamp desc) = 1
     """
 


### PR DESCRIPTION
# Goal
We are importing raw engagement data from BigQuery to Snowflake. It appears that there are several instances of duplicate data in the imports into Snowflake. We have also found events that have no relevance to our use case (example: events not associated with engagements, page pings).  
The goal is to add query filters cleanup the data before importing into Snowflake

# Implementation
- Remove duplicate during import
- Filter out irrelevant data

 