### PR TITLE
Filter to exclude non Pocket CN NewTab

### DIFF
--- a/src/flows/ff_new_tab_engagement.py
+++ b/src/flows/ff_new_tab_engagement.py
@@ -31,6 +31,7 @@ EXPORT_SQL = """
           FROM `moz-fx-data-shared-prod.activity_stream_live.impression_stats_v1`
           where date(submission_timestamp) >= date(@last_executed_timestamp)
           and submission_timestamp > @last_executed_timestamp
+          and page != 'https://newtab.firefoxchina.cn/newtab/as/activity-stream.html'  -- exclude non-Pocket CN NewTab
           and loaded is null --don't include loaded ping
           and array_length(tiles) >= 1 --making sure data is valid/non-empty
           qualify row_number() over (partition by document_id order by submission_timestamp desc) = 1


### PR DESCRIPTION
# Goal

Exclude the non Pocket China NewTab pages

# Implementation

Add the filter `page != 'https://newtab.firefoxchina.cn/newtab/as/activity-stream.html'` to the BigQuery export query
