### PR TITLE
fix(set_last_loaded_at): Only compute max loaded_at if input is non-empty

### DIFF
--- a/src/flows/braze_update_flow.py
+++ b/src/flows/braze_update_flow.py
@@ -118,12 +118,14 @@ def set_last_loaded_at(user_deltas: List[UserDelta]):
     Update the KV-store value for the loaded_at_start query parameter to the maximum loaded_at value in user_deltas.
     :param user_deltas:
     """
-    max_loaded_at = str(max(u.loaded_at for u in user_deltas))
-
     logger = context.get("logger")
-    logger.info(f"Setting {LAST_LOADED_AT_KV_STORE_KEY} to {max_loaded_at}")
+    if user_deltas:
+        max_loaded_at = str(max(u.loaded_at for u in user_deltas))
+        logger.info(f"Setting {LAST_LOADED_AT_KV_STORE_KEY} to {max_loaded_at}")
+        set_kv(key=LAST_LOADED_AT_KV_STORE_KEY, value=max_loaded_at)
+    else:
+        logger.info(f"{LAST_LOADED_AT_KV_STORE_KEY} is not updated because we did not query any rows from Snowflake.")
 
-    set_kv(key=LAST_LOADED_AT_KV_STORE_KEY, value=max_loaded_at)
 
 
 @task()


### PR DESCRIPTION
## Goal
Fix uncaught exception in `set_last_loaded_at` task:
```
ValueError: max() arg is an empty sequence
```
This happens if we didn't query any rows from Snowflake.

## References
Logs: https://cloud.prefect.io/pocket/task-run/2ff351fb-d882-43c3-ba04-453284570ea8?logs

## QA
In my local environment I set the loaded_at start date to the future and ran the flow.
```sql
WHERE LOADED_AT > '2022-04-01'
```
As expected we now get a log statement saying there are no rows:
```
prefect_1  | [2022-03-29 17:20:34+0000] INFO - prefect.set_last_loaded_at | local/braze_update_flow/last_loaded_at is not updated because we did not query any rows from Snowflake.
```