### PR TITLE
Increase flow task size to 4 vCPU and 30GB of memory

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -26,8 +26,8 @@ const prefect = {
   flowTask: {
     // See the documentation below for valid values for CPU and memory:
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu
-    cpu: 1024,
-    memory: 8192,
+    cpu: 4096, // 4096 = 4 vCPU
+    memory: 30720, // 30720 = 30GB
     dataLearningBucketName: isDev
       ? 'pocket-data-learning-dev'
       : 'pocket-data-learning',


### PR DESCRIPTION
# Goal
Increase memory from 8GB to 30GB to prevent the backfill from running out of memory. It seems to be running out of memory shortly after query Snowflake.
![Screenshot from 2022-04-05 12-39-28](https://user-images.githubusercontent.com/1547251/161836211-970607c7-0eba-4293-9d46-1ccfcf7604b2.png)
