### PR TITLE
Setting flow schedules for Prod only deployments

### DIFF
--- a/src/flows/dbt_orchestration_flow.py
+++ b/src/flows/dbt_orchestration_flow.py
@@ -1,15 +1,12 @@
-import datetime
-
 from prefect import Flow
 from prefect.tasks.dbt import dbt
 from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
 from prefect.executors import LocalDaskExecutor
-from prefect.schedules import IntervalSchedule
 from utils import config
 
 from flows.braze import update_flow as braze_update_flow
 from flows.prospecting import prereview_engagement_feature_store_flow, postreview_engagement_feature_store_flow
-from utils.flow import get_flow_name
+from utils.flow import get_flow_name, get_interval_schedule
 
 FLOW_NAME = get_flow_name(__file__)
 DBT_CLOUD_JOB_ID = 52822
@@ -22,13 +19,7 @@ DBT_DOWNSTREAM_FLOW_NAMES = [
     postreview_engagement_feature_store_flow.FLOW_NAME,
 ]
 
-# Schedule to run every 5 minutes
-if config.ENVIRONMENT == config.ENV_PROD:
-    schedule = IntervalSchedule(interval=datetime.timedelta(minutes=10))
-else:
-    schedule = None
-
-with Flow(FLOW_NAME, schedule=schedule, executor=LocalDaskExecutor()) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=10), executor=LocalDaskExecutor()) as flow:
 
     dbt_run_result = dbt.DbtCloudRunJob()(cause=FLOW_NAME, job_id=DBT_CLOUD_JOB_ID, wait_for_job_run_completion=True)
 

--- a/src/flows/recommendation_api/ff_new_tab_engagement.py
+++ b/src/flows/recommendation_api/ff_new_tab_engagement.py
@@ -1,10 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import prefect
 from prefect import Flow, task
-from prefect.schedules import IntervalSchedule
 from prefect.tasks.gcp.bigquery import BigQueryTask
 from utils import config
-from utils.flow import get_flow_name
+from utils.flow import get_flow_name, get_interval_schedule
 from api_clients.prefect_key_value_store_client import get_last_executed_value, update_last_executed_value
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery
 
@@ -151,13 +150,7 @@ def prepare_exp_imp_params(last_executed_timestamp: datetime):
 
     return bq_export_query_param_list, snowflake_import_param
 
-# Schedule to run every 5 minutes
-schedule = IntervalSchedule(
-    start_date=datetime.utcnow() + timedelta(seconds=1),
-    interval=timedelta(minutes=5),
-)
-
-with Flow(FLOW_NAME, schedule) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=5)) as flow:
     last_executed_timestamp = get_last_executed_value(flow_name=FLOW_NAME,
                                                   default_if_absent=str(datetime.utcnow())
                                                   )

--- a/src/utils/flow.py
+++ b/src/utils/flow.py
@@ -1,8 +1,10 @@
 import re
+from datetime import timedelta
 
 from prefect.engine.results import S3Result
+from prefect.schedules import IntervalSchedule
 
-from utils.config import PREFECT_S3_RESULT_BUCKET
+from utils.config import PREFECT_S3_RESULT_BUCKET, ENVIRONMENT, ENV_PROD
 
 
 def get_flow_name(file_path: str) -> str:
@@ -18,3 +20,15 @@ def get_s3_result() -> S3Result:
     :return: Prefect S3Result that can be set on the flow, which allow us to resume flows from failure using data in S3.
     """
     return S3Result(bucket=PREFECT_S3_RESULT_BUCKET)
+
+
+def get_interval_schedule(minutes: int) -> IntervalSchedule:
+    """
+    :return: Prefect IntervalSchedule for PROD only environment.
+    """
+    if ENVIRONMENT == ENV_PROD:
+        schedule = IntervalSchedule(interval=timedelta(minutes=minutes))
+    else:
+        schedule = None
+
+    return schedule


### PR DESCRIPTION
## Goal

To implement Prefect Flow schedules to be set for the Production environment only for the FF New Tab Flow. Previously, the schedules were being deployed to both the deployment environments (Production and Development)

## Implementation Decisions

While the required change to the FF New Tab Flow was being done, an improvement to create a common function `utils.flow.get_interval_schedule` has been created that applies the schedule for the PROD environment only and is now being used in each Flow where schedule is required.
