### PR TITLE
[HS-34] Create a simple corpus candidates set

### DIFF
--- a/src/flows/recommendation_api/curated_corpus_candidates_flow.py
+++ b/src/flows/recommendation_api/curated_corpus_candidates_flow.py
@@ -11,7 +11,7 @@ from sagemaker.session import Session
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
 from utils import config
-from utils.flow import get_flow_name
+from utils.flow import get_flow_name, get_interval_schedule
 
 FLOW_NAME = get_flow_name(__file__)
 
@@ -53,7 +53,7 @@ def load_feature_record(record: Sequence[FeatureValue], feature_group_name):
     feature_group.put_record(record)
 
 
-with Flow(FLOW_NAME) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_CORPUS_ITEMS_SQL,
         data={

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -23,6 +23,10 @@ SNOWFLAKE_ANALYTICS_DBT_STAGING_SCHEMA = os.getenv(
     'SNOWFLAKE_ANALYTICS_DBT_STAGING_SCHEMA',
     'DBT_STAGING'  # For local development, set the Dbt staging schema in .env
 )
+SNOWFLAKE_ANALYTICS_DBT_SCHEMA = os.getenv(
+    'SNOWFLAKE_ANALYTICS_DBT_STAGING_SCHEMA',
+    'DBT_STAGING'  # For local development, set the Dbt staging schema in .env
+)
 
 BRAZE_API_KEY=os.getenv('BRAZE_API_KEY')
 BRAZE_REST_ENDPOINT=os.getenv('BRAZE_REST_ENDPOINT')

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -23,10 +23,7 @@ SNOWFLAKE_ANALYTICS_DBT_STAGING_SCHEMA = os.getenv(
     'SNOWFLAKE_ANALYTICS_DBT_STAGING_SCHEMA',
     'DBT_STAGING'  # For local development, set the Dbt staging schema in .env
 )
-SNOWFLAKE_ANALYTICS_DBT_SCHEMA = os.getenv(
-    'SNOWFLAKE_ANALYTICS_DBT_STAGING_SCHEMA',
-    'DBT_STAGING'  # For local development, set the Dbt staging schema in .env
-)
+SNOWFLAKE_ANALYTICS_DBT_SCHEMA = os.getenv('SNOWFLAKE_ANALYTICS_DBT_SCHEMA', 'DBT')
 
 BRAZE_API_KEY=os.getenv('BRAZE_API_KEY')
 BRAZE_REST_ENDPOINT=os.getenv('BRAZE_REST_ENDPOINT')


### PR DESCRIPTION
## Goal
Store a set of Corpus Items in the Feature Store that we can use to show people during onboarding. We include topics to allow RecommendationAPI to filter these candidates based on the topics that users will select.

## Corpus Candidate Sets feature group
This feature group stores a set of corpus items based on a unique identifier, similar to the `RECAPI-Dev-CandidateSets` DynamoDB table, but with CorpusItems instead of legacy Pocket items.

| Feature Name | Feature Type                                              |
|--------------|-----------------------------------------------------------|
| id           | String                                                    |
| unloaded_at  | String                                                    |
| corpus_items | String (JSON list of Corpus Items, with 'id' and 'topic') |

## Implementation Decisions
- Include any approved items, not just scheduled ones, to get more stories for each topic.
- For now, sort simply on recency.

## Deployment
- [x] Create feature group `development-corpus-candidate-sets-v1`
- [x] Create feature group `production-corpus-candidate-sets-v1`

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/HS-34