### PR TITLE
Limit setup moment recs to syndicated

### DIFF
--- a/src/flows/recommendation_api/curated_corpus_candidates_flow.py
+++ b/src/flows/recommendation_api/curated_corpus_candidates_flow.py
@@ -15,7 +15,7 @@ from utils.flow import get_flow_name, get_interval_schedule
 
 FLOW_NAME = get_flow_name(__file__)
 
-NEW_TAB_EN_US_CORPUS_CANDIDATE_SET_ID = 'deea0f06-9dc9-44a5-b864-fea4a4d0beb7'
+SETUP_MOMENT_CORPUS_CANDIDATE_SET_ID = 'deea0f06-9dc9-44a5-b864-fea4a4d0beb7'
 
 # Export approved corpus items by language and recency
 EXPORT_CORPUS_ITEMS_SQL = """
@@ -68,7 +68,7 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
 
     feature_group = Parameter("feature group", default=f"{config.ENVIRONMENT}-corpus-candidate-sets-v1")
     feature_group_record = create_corpus_candidate_set_record(
-        id=NEW_TAB_EN_US_CORPUS_CANDIDATE_SET_ID,
+        id=SETUP_MOMENT_CORPUS_CANDIDATE_SET_ID,
         corpus_items=corpus_items,
     )
     load_feature_record(feature_group_record, feature_group_name=feature_group)

--- a/src/flows/recommendation_api/curated_corpus_candidates_flow.py
+++ b/src/flows/recommendation_api/curated_corpus_candidates_flow.py
@@ -24,6 +24,7 @@ SELECT
     TOPIC
 FROM "APPROVED_CORPUS_ITEMS"
 WHERE LANGUAGE = %(language)s
+AND IS_SYNDICATED = TRUE
 AND REVIEWED_CORPUS_ITEM_CREATED_AT BETWEEN DATEADD(day, %(scheduled_at_start_day)s, CURRENT_TIMESTAMP) AND CURRENT_TIMESTAMP
 ORDER BY REVIEWED_CORPUS_ITEM_CREATED_AT DESC
 LIMIT 500;
@@ -57,7 +58,7 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_CORPUS_ITEMS_SQL,
         data={
-            'scheduled_at_start_day': -14,
+            'scheduled_at_start_day': -60,
             'language': 'EN',
         },
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,


### PR DESCRIPTION
## Goal
Return only syndicated items for the Setup Moment Slate.

## Implementation Decisions
Extend review window to 60 days in the past to get more content for rare topics.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/HS-53?atlOrigin=eyJpIjoiYjBkNzE2MzQzNDM4NGE2NjliZTM5NWY1OTJkZGI2NWQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

Slack thread:
* https://pocket.slack.com/archives/C03AGDGJ1E0/p1654553328130439

## Query to show the number of stories per topic
```sql
WITH candidates as (
  SELECT * FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
  WHERE LANGUAGE = 'EN'
  AND IS_SYNDICATED = TRUE
  ORDER BY REVIEWED_CORPUS_ITEM_CREATED_AT DESC
  LIMIT 1000
)
SELECT
    topic,
    COUNT_IF(REVIEWED_CORPUS_ITEM_CREATED_AT > DATEADD(day, -15, CURRENT_TIMESTAMP)) as count_15_days,
    COUNT_IF(REVIEWED_CORPUS_ITEM_CREATED_AT > DATEADD(day, -30, CURRENT_TIMESTAMP)) as count_30_days,
    COUNT_IF(REVIEWED_CORPUS_ITEM_CREATED_AT > DATEADD(day, -60, CURRENT_TIMESTAMP)) as count_60_days,
    COUNT_IF(REVIEWED_CORPUS_ITEM_CREATED_AT > DATEADD(day, -90, CURRENT_TIMESTAMP)) as count_90_days
FROM candidates
WHERE topic not in ('GAMING', 'SPORTS', 'EDUCATION', 'CORONAVIRUS')
GROUP BY 1
ORDER BY count(*) asc;
```