### PR TITLE
Fix deployment issue with missing base64 Snowflake key

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -29,10 +29,11 @@ SNOWFLAKE_ANALYTICS_DBT_SCHEMA = os.getenv('SNOWFLAKE_ANALYTICS_DBT_SCHEMA', 'DB
 BRAZE_API_KEY=os.getenv('BRAZE_API_KEY')
 BRAZE_REST_ENDPOINT=os.getenv('BRAZE_REST_ENDPOINT')
 
+_BASE64_SNOWFLAKE_PRIVATE_KEY = os.getenv("SNOWFLAKE_PRIVATE_KEY")
 SNOWFLAKE_DATA_RETENTION_CONNECTION_DICT = {
     "account": os.getenv("SNOWFLAKE_ACCOUNT"),
     "user": os.getenv("SNOWFLAKE_USER"),
-    "private_key": base64.b64decode(os.getenv("SNOWFLAKE_PRIVATE_KEY")),
+    "private_key": base64.b64decode(_BASE64_SNOWFLAKE_PRIVATE_KEY) if _BASE64_SNOWFLAKE_PRIVATE_KEY else None,
     "warehouse": os.getenv("SNOWFLAKE_WAREHOUSE"),
     "role": os.getenv("SNOWFLAKE_DATA_RETENTION_ROLE"),
     "database": os.getenv('SNOWFLAKE_DATA_RETENTION_DB'),


### PR DESCRIPTION
## Goal
All our flows have started failing since the last deployment.

Maybe this is because the [last deployment](https://us-east-1.console.aws.amazon.com/codesuite/codepipeline/pipelines/DataFlows-Prod-CodePipeline/view?region=us-east-1) failed halfway through with the following error?
```
File "<string>", line 5, in <module>
File "/src/utils/config.py", line 35, in <module>
  "private_key": base64.b64decode(os.getenv("SNOWFLAKE_PRIVATE_KEY")),
File "/usr/local/lib/python3.9/base64.py", line 80, in b64decode
  s = _bytes_from_decode_data(s)
File "/usr/local/lib/python3.9/base64.py", line 45, in _bytes_from_decode_data
  raise TypeError("argument should be a bytes-like object or ASCII "
TypeError: argument should be a bytes-like object or ASCII string, not 'NoneType'
```


## Implementation Decisions
I'm applying a quick fix. We should consider maybe moving the `base64.b64decode` call out of config.py and into a Prefect task. For example, `PocketSnowflakeQuery` does this as part of the `run()` call.

## References

Slack thread:
* https://pocket.slack.com/archives/C02KH5U7G79/p1656010263154229