### PR TITLE
Run the Deleted User Account data deletion on a separate Snowflake warehouse

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -50,6 +50,7 @@ const prefect = {
       'SNOWFLAKE_SNOWPLOW_SCHEMA',
       'SNOWFLAKE_RAWDATA_DB',
       'SNOWFLAKE_RAWDATA_FIREHOSE_SCHEMA',
+      'SNOWFLAKE_DATA_RETENTION_WAREHOUSE',
     ],
     // Use the existing 'PocketDataProductReadOnly' policy. It currently only exists in production.
     // @see https://github.com/Pocket/data-shared/blob/main/lib/permissions-stack.ts#L14

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Replace `{Env}` with the environment name as defined in
 | `/DataFlows/{Env}/SNOWFLAKE_SNOWPLOW_SCHEMA`               | String       | Snowflake Schema that has the Snowplow raw events.                                         |
 | `/DataFlows/{Env}/SNOWFLAKE_RAWDATA_DB`                    | String       | Snowflake DB that has the legacy Raw events.                                               |
 | `/DataFlows/{Env}/SNOWFLAKE_RAWDATA_FIREHOSE_SCHEMA`       | String       | Snowflake Schema that has the legacy Raw events.                                           |
+| `/DataFlows/{Env}/SNOWFLAKE_DATA_RETENTION_WAREHOUSE`      | String       | Snowflake Warehouse used for data deletions of Deleted User Accounts.                      |
 
 ## Roadmap
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -34,7 +34,7 @@ SNOWFLAKE_DATA_RETENTION_CONNECTION_DICT = {
     "account": os.getenv("SNOWFLAKE_ACCOUNT"),
     "user": os.getenv("SNOWFLAKE_USER"),
     "private_key": base64.b64decode(_BASE64_SNOWFLAKE_PRIVATE_KEY) if _BASE64_SNOWFLAKE_PRIVATE_KEY else None,
-    "warehouse": os.getenv("SNOWFLAKE_WAREHOUSE"),
+    "warehouse": os.getenv("SNOWFLAKE_DATA_RETENTION_WAREHOUSE"),
     "role": os.getenv("SNOWFLAKE_DATA_RETENTION_ROLE"),
     "database": os.getenv('SNOWFLAKE_DATA_RETENTION_DB'),
     "schema": os.getenv('SNOWFLAKE_DATA_RETENTION_SCHEMA')


### PR DESCRIPTION
## Goal

To use a separate Snowflake warehouse to run the data deletions for Deleted User Accounts
This data deletion process runs monthly over many large data sets. Running this job on a separate warehouse will prevent contention and impact on other active Prefect jobs.

## Implementation Decisions

Adding `SNOWFLAKE_DATA_RETENTION_WAREHOUSE` environment variable for this new Snowflake warehouse

- [x] `/DataFlows/Prod/SNOWFLAKE_DATA_RETENTION_WAREHOUSE`: Add to Parameter store
- [x] Add `SNOWFLAKE_DATA_RETENTION_WAREHOUSE` to README
- [x] Add `SNOWFLAKE_DATA_RETENTION_WAREHOUSE` to .aws/src/config/index.ts
