### PR TITLE
Removing deleted accounts from Stripe

### DIFF
--- a/src/flows/data_retention/delete_stripe_table_rows.sql
+++ b/src/flows/data_retention/delete_stripe_table_rows.sql
@@ -1,0 +1,9 @@
+--
+-- BEGIN: FIVETRAN.STRIPE
+use schema FIVETRAN.STRIPE;
+
+DELETE FROM CUSTOMER as s
+where IS_DELETED = true;
+
+DELETE FROM CARD as s
+where IS_DELETED = true;

--- a/src/flows/data_retention/deleted_accounts_flow.py
+++ b/src/flows/data_retention/deleted_accounts_flow.py
@@ -20,8 +20,8 @@ def query_file(file_name: str, **kwargs):
     )
 
 
-# with Flow(FLOW_NAME, schedule=get_cron_schedule(cron="0 0 1 * *")) as flow:
-with Flow(FLOW_NAME) as flow:
+with Flow(FLOW_NAME, schedule=get_cron_schedule(cron="0 0 15 * *")) as flow:
+
     # Maintain a list of deleted accounts in a protected DB/Schema tables
     add_deleted_users_result = query_file(file_name='deleted_account_users.sql',
                                           task_args=dict(name="SavingDeletedUserAccount_user_ids")
@@ -60,10 +60,16 @@ with Flow(FLOW_NAME) as flow:
                                         task_args=dict(name="DeletingRawData_SnapshotFirehose")
                                         )
 
-    # Delete Snapshot.Redshift data for deleted user accounts
-    delete_snapshot_redshift_data_result = query_file(file_name='delete_miscellaneous_table_rows.sql',
+    # Delete Miscellaneous table data for deleted user accounts
+    delete_miscellaneous_data_result = query_file(file_name='delete_miscellaneous_table_rows.sql',
                                         upstream_tasks=backup_results,
                                         task_args=dict(name="DeletingRawData_MiscellaneousTable")
+                                        )
+
+    # Delete Stripe data for deleted user accounts
+    delete_stripe_data_result = query_file(file_name='delete_stripe_table_rows.sql',
+                                        upstream_tasks=backup_results,
+                                        task_args=dict(name="DeletingRawData_Stripe")
                                         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

- Adding script for removing Stripe deleted account data
- Adding a schedule to automate the deletion process to run on the 15th of every month

## Implementation Decisions
 
The criteria for identifying deleted user accounts is based on the `is_deleted=true` flag
Currently there are 2 tables (`CUSTOMER` and `CARD`) that have the  `is_deleted=true` flag set. The script deletes data from these 2 tables for the data identified as deleted.

## Reference
Slack conversation: https://pocket.slack.com/archives/C03E28D1GUD/p1654892275342369

