### PR TITLE
Create flow to write editorial candidates to feature store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,4 @@ services:
       - PREFECT__CLOUD__AGENT__LEVEL=DEBUG
       - AWS_DEFAULT_REGION=us-east-1
       - RUN_TASK_KWARGS=foobar
+      - GIT_SHA=local

--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Dict, Sequence
+from typing import Dict, Sequence, List
 
 import boto3
 from prefect import task, Parameter
@@ -9,6 +9,19 @@ from sagemaker.feature_store.feature_group import FeatureGroup
 from sagemaker.feature_store.inputs import FeatureValue
 
 from utils import config
+
+
+@task()
+def validate_corpus_items(corpus_items: List[Dict]):
+    min_item_count = 1
+    expected_keys = ['ID', 'TOPIC']
+
+    assert len(corpus_items) >= min_item_count
+    assert all(list(corpus_item.keys()) == expected_keys for corpus_item in corpus_items)
+    assert all(corpus_item['ID'] for corpus_item in corpus_items)
+    assert all(corpus_item['TOPIC'] for corpus_item in corpus_items)
+
+    return corpus_items
 
 
 @task()

--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -1,0 +1,37 @@
+import datetime
+import json
+from typing import Dict, Sequence
+
+import boto3
+from prefect import task, Parameter
+from sagemaker import Session
+from sagemaker.feature_store.feature_group import FeatureGroup
+from sagemaker.feature_store.inputs import FeatureValue
+
+from utils import config
+
+
+@task()
+def create_corpus_candidate_set_record(
+        id: str,
+        corpus_items: Dict,
+        unloaded_at: datetime.datetime = datetime.datetime.now()
+) -> Sequence[FeatureValue]:
+    return [
+        FeatureValue('id', id),
+        FeatureValue('unloaded_at', unloaded_at.strftime("%Y-%m-%dT%H:%M:%SZ")),
+        FeatureValue('corpus_items', json.dumps(corpus_items)),
+    ]
+
+
+@task()
+def load_feature_record(record: Sequence[FeatureValue], feature_group_name):
+    boto_session = boto3.Session()
+    feature_store_session = Session(boto_session=boto_session,
+                                    sagemaker_client=boto_session.client(service_name='sagemaker'),
+                                    sagemaker_featurestore_runtime_client=boto_session.client(service_name='sagemaker-featurestore-runtime'))
+    feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
+    feature_group.put_record(record)
+
+
+feature_group = Parameter("feature group", default=f"{config.ENVIRONMENT}-corpus-candidate-sets-v1")

--- a/src/flows/recommendation_api/curated_corpus_candidates_flow.py
+++ b/src/flows/recommendation_api/curated_corpus_candidates_flow.py
@@ -1,7 +1,12 @@
 from prefect import Flow, Parameter
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
-from common_tasks.corpus_candidate_set import create_corpus_candidate_set_record, load_feature_record
+from common_tasks.corpus_candidate_set import (
+    create_corpus_candidate_set_record,
+    load_feature_record,
+    feature_group,
+    validate_corpus_items,
+)
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 
@@ -35,7 +40,8 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
         output_type=OutputType.DICT,
     )
 
-    feature_group = Parameter("feature group", default=f"{config.ENVIRONMENT}-corpus-candidate-sets-v1")
+    corpus_items = validate_corpus_items(corpus_items)
+
     feature_group_record = create_corpus_candidate_set_record(
         id=SETUP_MOMENT_CORPUS_CANDIDATE_SET_ID,
         corpus_items=corpus_items,

--- a/src/flows/recommendation_api/setup_moment_editorial_candidates_flow.md
+++ b/src/flows/recommendation_api/setup_moment_editorial_candidates_flow.md
@@ -1,0 +1,21 @@
+Data taken from: https://docs.google.com/spreadsheets/d/1gdl9695Ib6Kd0OUX28yD03wJzRAcHiKZkZqn9DVdI2I/edit#gid=1108537720
+
+Steps to dump this data:
+1. Use Snowflake to dump all syndicated items from the Corpus:
+    ```sql
+    SELECT URL, APPROVED_CORPUS_ITEM_EXTERNAL_ID as CORPUS_ID, TITLE, TOPIC
+    FROM "APPROVED_CORPUS_ITEMS"
+    WHERE IS_SYNDICATED = TRUE
+    ORDER BY URL ASC;
+    ```
+2. Open the spreadsheet above. In the 'Syndicated Corpus Items' sheet, choose File > Import. Select the Snowflake dump.
+3. Go to the 'FINAL PICKS' sheet. Check that the 'ID' column has values for every row.
+4. copy the 'ID' column into a text editor / IDE.
+5. Convert CSV to Python by doing a regex replace all:
+    ```regexp
+    Find:
+    ^(.*)$
+    
+    Replace with:
+    "$1", 
+    ```

--- a/src/flows/recommendation_api/setup_moment_editorial_candidates_flow.py
+++ b/src/flows/recommendation_api/setup_moment_editorial_candidates_flow.py
@@ -12,19 +12,7 @@ SETUP_MOMENT_EDITORIAL_CORPUS_CANDIDATE_SET_ID = '57d544d6-0758-4cd1-a7b4-86f454
 """
 Data taken from: https://docs.google.com/spreadsheets/d/1gdl9695Ib6Kd0OUX28yD03wJzRAcHiKZkZqn9DVdI2I/edit#gid=1108537720
 
-Steps to dump this data:
-1. Use Snowflake to dump all syndicated items from the Corpus:
-    ```sql
-    SELECT URL, APPROVED_CORPUS_ITEM_EXTERNAL_ID as CORPUS_ID, TITLE, TOPIC
-    FROM "APPROVED_CORPUS_ITEMS"
-    WHERE IS_SYNDICATED = TRUE
-    ORDER BY URL ASC;
-    ```
-2. Open the spreadsheet above. In the 'Syndicated Corpus Items' sheet, choose File > Import. Select the Snowflake dump.
-3. In the 'FINAL PICKS' sheet, copy the 'ID' and 'TOPIC' column into a text editor / IDE.
-4. Convert CSV to Python by doing a regex replace all:
-^(.*)$
-"$1", 
+For steps how to dump this data see the flow readme (setup_moment_editorial_candidates_flow.md).
 """
 CORPUS_IDS = [
     "d65e5540-6d1b-44d5-b3b7-40c3058d5f9e",

--- a/src/flows/recommendation_api/setup_moment_editorial_candidates_flow.py
+++ b/src/flows/recommendation_api/setup_moment_editorial_candidates_flow.py
@@ -1,0 +1,114 @@
+from prefect import Flow
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from common_tasks.corpus_candidate_set import create_corpus_candidate_set_record, load_feature_record, feature_group
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+
+FLOW_NAME = get_flow_name(__file__)
+
+SETUP_MOMENT_EDITORIAL_CORPUS_CANDIDATE_SET_ID = '57d544d6-0758-4cd1-a7b4-86f454c8eae8'
+
+"""
+Data taken from: https://docs.google.com/spreadsheets/d/1gdl9695Ib6Kd0OUX28yD03wJzRAcHiKZkZqn9DVdI2I/edit#gid=1108537720
+
+Steps to dump this data:
+1. Use Snowflake to dump all syndicated items from the Corpus:
+    ```sql
+    SELECT URL, APPROVED_CORPUS_ITEM_EXTERNAL_ID as CORPUS_ID, TITLE, TOPIC
+    FROM "APPROVED_CORPUS_ITEMS"
+    WHERE IS_SYNDICATED = TRUE
+    ORDER BY URL ASC;
+    ```
+2. Open the spreadsheet above. In the 'Syndicated Corpus Items' sheet, choose File > Import. Select the Snowflake dump.
+3. In the 'FINAL PICKS' sheet, copy the 'ID' and 'TOPIC' column into a text editor / IDE.
+4. Convert CSV to Python by doing a regex replace all:
+^(.*)$
+"$1", 
+"""
+CORPUS_IDS = [
+    "d65e5540-6d1b-44d5-b3b7-40c3058d5f9e",
+    "711c3163-2e66-40c5-874a-6d61d165160d",
+    "0cceec34-8f2e-4801-b54c-c777b53a6b7a",
+    "7070468d-fcd7-4aef-bb7b-1f162878e900",
+    "d648a0af-0e75-46c6-b827-60918ef252c4",
+    "0236d9fc-6d5a-4057-9c55-dbcfb902354f",
+    "97160702-62a1-4501-9ced-cb3bee5449a1",
+    "3fb298ac-90f2-428b-97d4-4156d8da921b",
+    "c3be0f4b-13dd-4c9a-97bc-1d86ded08737",
+    "cf478515-6235-4328-827a-f121e84d4fdb",
+    "777b0427-0d75-49de-a540-500c52fa4ba6",
+    "8f0f9172-73f7-43f5-abd8-b61f553f1273",
+    "d30c2b93-3f4c-48c2-8318-32f403a5a920",
+    "e339245c-7be8-4076-80cd-cc6d3a923f4b",
+    "87d4f8c1-97a2-4609-b9a2-4be602833ee0",
+    "1374dd3f-ccd8-4f7b-a83c-6a6b9e9fc3cc",
+    "65ae6dd4-4308-4e06-b7e2-295bf4f884ef",
+    "ba0330fb-b3e8-4eb0-aa02-8e9633f11f33",
+    "0d1ffddf-194b-490c-af88-5ed4735c7fa0",
+    "3ac13df2-0337-404e-a43c-a7299c998583",
+    "78d4349f-0147-4ece-9058-e24f9b43542f",
+    "a13b4c15-39f5-4c6a-bb2e-a88dd082785a",
+    "8435a8d6-7622-474d-9cbd-9dde57cc01e1",
+    "9cbde37c-dd53-437d-b2b6-9f4939dbbd6a",
+    "8e34de82-bf6e-4edb-a5bf-7f16ad9d46a6",
+    "414d2ef4-9623-4e1c-a623-96306a5237e1",
+    "ddd89891-6ac1-40b5-88d6-f9862855ad14",
+    "030ee0fc-0279-4a9a-b955-3bfa1581b4cd",
+    "ad2a6668-6e08-4fc0-9018-1b287e76c5c1",
+    "835921e7-9700-4f20-8e5f-4e5e3e3a2a9e",
+    "f3ffd924-027c-4141-9bd2-5d3150336f2d",
+    "f17ccc1d-ea4a-4daa-9234-f7a517fadf4c",
+    "37b78dbe-5b30-4467-aa21-1e953274ca5a",
+    "9faeea4f-ee3d-46ee-9e8b-3e2c0271eccb",
+    "3fbd3b29-b18d-4e6f-827c-e39fbcb4d8cf",
+    "bfe9f816-bd76-4522-b8f9-52263ae2c9ed",
+    "49651a9e-2e19-4c25-b07a-b85d9c1462fc",
+    "e1d1a192-73ae-4620-a6d2-7754aecc27a8",
+    "b7013a6e-50e7-47a6-8862-cf073b8a37a0",
+    "60cc9b9b-f926-431c-b8d4-97a0b5f58c35",
+    "54f564b3-2eb4-424c-8087-8f624ff6d593",
+    "1d8d2f22-7cef-4542-a3f8-827b4c01ce2f",
+    "5284c1d4-7ced-4b19-8c69-8c48f38e5ce1",
+    "d925b4aa-73bd-4f6d-bbb8-62a55cb75721",
+    "b5ee84bb-2927-458f-8a6e-9461308714f5",
+    "06baca35-2c22-4911-a70e-adb561dcc147",
+    "e8dd547d-2db3-4e79-885a-f73bd246fb04",
+    "e051efb0-6ec3-4752-96cc-f6b14eaeb201",
+    "7b246ab7-5baf-4c34-90a7-eec02ba47321",
+    "c4265085-6f10-4844-9395-7cea0ea83f6b",
+]
+
+"""
+NOTE: I couldn't immediately find how to bind a list for parameterizing an IN clause. It's important to parameterize
+      any value that can be user-controlled. In this case values are hard-coded, so it's safe to insert them directly.   
+"""
+EXPORT_CORPUS_ITEMS_SQL = f"""
+SELECT
+    APPROVED_CORPUS_ITEM_EXTERNAL_ID as ID,
+    TOPIC
+FROM "APPROVED_CORPUS_ITEMS"
+WHERE APPROVED_CORPUS_ITEM_EXTERNAL_ID IN ({",".join(f"'{corpus_id}'" for corpus_id in CORPUS_IDS)});
+"""
+
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+    corpus_items = PocketSnowflakeQuery()(
+        query=EXPORT_CORPUS_ITEMS_SQL,
+        data={
+            'scheduled_at_start_day': -60,
+            'language': 'EN',
+        },
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DICT,
+    )
+
+    feature_group_record = create_corpus_candidate_set_record(
+        id=SETUP_MOMENT_EDITORIAL_CORPUS_CANDIDATE_SET_ID,
+        corpus_items=corpus_items,
+    )
+    load_feature_record(feature_group_record, feature_group_name=feature_group)
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/test/common_tasks/test_corpus_candidate_set.py
+++ b/src/test/common_tasks/test_corpus_candidate_set.py
@@ -1,0 +1,62 @@
+import json
+import re
+import uuid
+from typing import Dict, List
+
+import pytest
+
+from common_tasks.corpus_candidate_set import validate_corpus_items, create_corpus_candidate_set_record
+
+
+@pytest.fixture
+def corpus_items_100():
+    return [{'ID': str(uuid.uuid4()), 'TOPIC': str(i)} for i in range(100)]
+
+
+@pytest.fixture
+def corpus_candidate_set_id():
+    return str(uuid.uuid4())
+
+
+def test_validate_corpus_items_does_not_raise_an_exception(corpus_items_100):
+    validate_corpus_items.run([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': 'BUSINESS'}])
+
+
+def test_validate_corpus_items_returns_corpus_items(corpus_items_100):
+    assert corpus_items_100 == validate_corpus_items.run(corpus_items_100)
+
+
+@pytest.mark.parametrize(
+    "corpus_items",
+    [
+        ([]),                                                                     # List must be non-empty
+        ([{'TOPIC': 'BUSINESS'}]),                                                # Must contain 'ID' key
+        ([{'id': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a'}]),                       # Must contain 'TOPIC'
+        ([{'id': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': 'BUSINESS'}]),  # 'ID' key is case-sensitive
+        ([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'Topic': 'BUSINESS'}]),  # 'TOPIC' key is case-sensitive
+        ([{'ID': '', 'TOPIC': 'BUSINESS'}]),                                      # 'ID' key must be non-empty
+        ([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': ''}]),          # 'TOPIC' must be non-empty
+        ([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': 'BUSINESS', 'FOO': 'BAR'}]),  # No other keys expected
+    ],
+)
+def test_validate_corpus_items_assertion_failed(corpus_items: List[Dict]):
+    with pytest.raises(AssertionError):
+        validate_corpus_items.run(corpus_items)
+
+
+def test_create_corpus_candidate_set_record(corpus_candidate_set_id, corpus_items_100):
+    feature_values = create_corpus_candidate_set_record.run(
+        id=corpus_candidate_set_id,
+        corpus_items=corpus_items_100,
+    )
+
+    assert len(feature_values) == 3
+
+    assert feature_values[0].feature_name == 'id'
+    assert feature_values[0].value_as_string == corpus_candidate_set_id
+
+    assert feature_values[1].feature_name == 'unloaded_at'
+    assert re.match(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z', feature_values[1].value_as_string)  # ISO time format
+
+    assert feature_values[2].feature_name == 'corpus_items'
+    assert json.loads(feature_values[2].value_as_string) == corpus_items_100


### PR DESCRIPTION
## Goal
Load hardcoded candidates set from [a spreadsheet](https://docs.google.com/spreadsheets/d/1gdl9695Ib6Kd0OUX28yD03wJzRAcHiKZkZqn9DVdI2I/edit?usp=sharing) as a candidate set for Setup Moment onboarding.

Additional changes:
- I moved tasks shared between this flow and `setup_moment_editorial_candidates_flow.py` to `src/common_tasks/corpus_candidate_set.py`

## QA
1. Run the flow locally against Pocket-Dev.
2. Query Athena for corpus candidate sets:
  ```sql
  SELECT * FROM "sagemaker_featurestore"."development-corpus-candidate-sets-v1-1654266001" limit 10;
  ```

- [x] Expectation: It should include a record with id `57d544d6-0758-4cd1-a7b4-86f454c8eae8`.
- [x] Corpus items should contain `ID` and `TOPIC` keys.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/HS-73

Spreadsheet:
* https://docs.google.com/spreadsheets/d/1gdl9695Ib6Kd0OUX28yD03wJzRAcHiKZkZqn9DVdI2I/edit?usp=sharing

Slack thread:
* https://pocket.slack.com/archives/C03EYPH93GU/p1656359792704609
