### PR TITLE
Prospect training data flows

### DIFF
--- a/src/flows/prospecting/global_training_features_flow.py
+++ b/src/flows/prospecting/global_training_features_flow.py
@@ -1,0 +1,94 @@
+import datetime
+import pandas as pd
+import boto3
+
+from prefect import task, Flow, Parameter, case
+from prefect.tasks.control_flow import merge
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+
+DAY_IN_MINUTES = 1440
+FLOW_NAME = get_flow_name(__file__)
+
+def create_global_prospect_record(row: pd.Series):
+    now = datetime.datetime.utcnow()
+    now_as_string = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    record = [{"FeatureName": c,
+               "ValueAsString": str(row[c])} for c in row.index]
+    record.extend([{"FeatureName": "UNLOADED_AT", "ValueAsString": now_as_string},
+                   {"FeatureName": "VERSION", "ValueAsString": "0.1.0"}]
+                  )
+    return record
+
+def load_query(query_file: str) -> str:
+    print("loading inc query")
+    with open(query_file, "r") as fp:
+        query = fp.read()
+    return query
+
+
+@task()
+def check_refresh(refresh: bool):
+    return refresh == True
+
+@task()
+def load_refresh_query():
+    return load_query("global_training_full.sql")
+
+@task()
+def load_inc_query():
+    return load_query("global_training_inc.sql")
+
+@task()
+def load_feature_record(prospects_df: pd.DataFrame, feature_group_name: str):
+    fs_client = boto3.client('sagemaker-featurestore-runtime', region_name='us-east-1')
+
+    nitems = prospects_df.RESOLVED_ID.nunique()
+    print(f"update includes {len(prospects_df)} prospects ({nitems})")
+    responses = list()
+    for i, row in prospects_df.iterrows():
+        responses.append(fs_client.put_record(FeatureGroupName=feature_group_name,
+                                              Record=create_global_prospect_record(row)))
+
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=DAY_IN_MINUTES)) as flow:
+
+    # full_refresh if feature group needs to be rebuilt from scratch, e.g. schema change
+    full_refresh = Parameter("full_refresh", default=False)
+
+    training_feature_group = Parameter("feature group",
+                                       default=f"{config.ENVIRONMENT}-global-prospect-modeling-data-v1")
+
+    query_params = {
+        "PROSPECT_SURFACE_GUID": "NEW_TAB_EN_US",
+        "SURFACE_START_DATE": "2022-05-30",
+        "MAX_INC_AGE": 1,
+        "MAX_BACKFILL_AGE": 360,
+        "PROSPECT_LEGACY_FEED_ID": 1
+    }
+
+    refresh = check_refresh(full_refresh)
+    print(refresh)
+
+    with case(refresh, True):
+        query_r = load_refresh_query()
+
+    with case(refresh, False):
+        query_i = load_inc_query()
+
+    query = merge(query_i, query_r)
+
+    reviewed_prospects = PocketSnowflakeQuery()(
+        query=query,
+        data=query_params,
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DATA_FRAME,
+    )
+
+    load_feature_record(reviewed_prospects, feature_group_name=training_feature_group)
+
+if __name__ == "__main__":
+    flow.run(parameters=dict(full_refresh=True))

--- a/src/flows/prospecting/global_training_full.sql
+++ b/src/flows/prospecting/global_training_full.sql
@@ -1,0 +1,134 @@
+WITH latest_approvals AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.approved_corpus_items  -- model with historic curator decisions
+    WHERE loaded_from = 'PROSPECT'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND reviewed_corpus_item_created_at >  %(SURFACE_START_DATE)s  -- date when surface started in curation tool
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+),
+
+-- manual submissions to new tab by curators don't have prospect source information which
+-- currently comes from prospect candidate set model.  we need a scheduled surface which is
+-- only available in the scheduled_corpus_items model for those manual submissions that are
+-- scheduled (in addition to having status recommended)
+latest_manuals AS (
+
+    SELECT
+       content_id,
+       corpus_item_loaded_from as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.scheduled_corpus_items  -- model with historic curator decisions
+    WHERE corpus_item_loaded_from = 'MANUAL'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND reviewed_corpus_item_created_at >  %(SURFACE_START_DATE)s  -- date when surface started in curation tool
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+
+-- one year of prospects (rejected and approved) prior to the curation tool
+-- NEW_TAB_EN_US migrated to curation tool on 5/31/22
+-- this model includes historical approvals and rejections, airflow model only has approvals
+-- reviewed_corpus_item_prospects_merged doesn't include manual submissions
+backfill_prospects AS (
+
+    SELECT
+        c.content_id,
+        p.type,
+        p.status,
+        DATE (p.time_added) AS DATE_ADDED
+    FROM analytics.dbt_staging.stg_curated_feed_prospects as p
+    JOIN analytics.dbt.content as c
+      ON c.resolved_id = p.resolved_id
+    WHERE p.feed_id = %(PROSPECT_LEGACY_FEED_ID) s
+      AND DATEDIFF(day, p.time_added, %(SURFACE_START_DATE)s ) BETWEEN 0 AND %(MAX_BACKFILL_AGE) s
+
+),
+
+latest_rejects AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'denied' as STATUS, -- this is legacy label for rejected prospects to be consistent with backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.rejected_corpus_items  -- model with historic curator decisions
+    WHERE scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND reviewed_corpus_item_created_at >= %(SURFACE_START_DATE)s  -- date when surface started in curation tool
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+latest_curator_decisions as (
+    select * from latest_approvals
+    union
+    select * from latest_rejects
+    union
+    select * from backfill_prospects
+    union
+    select * from latest_manuals
+),
+
+
+action_counts as (
+    SELECT
+       a.CONTENT_ID,
+       a.RESOLVED_ID,
+       a.DOMAIN_ID,
+       a.TOP_DOMAIN_NAME AS PUBLISHER,
+       a.WORD_COUNT,
+       a.RESOLVED_URL,
+       a.TITLE,
+       p.TYPE,
+       p.STATUS,
+       p.DATE_ADDED,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) BETWEEN 0 AND 1
+           THEN a.SAVE_COUNT ELSE 0 END) AS day1_save_count,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 2
+           THEN a.SAVE_COUNT ELSE 0 END) AS day2_save_count,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 3
+           THEN a.SAVE_COUNT ELSE 0 END) AS day3_save_count,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 4
+           THEN a.SAVE_COUNT ELSE 0 END) AS day4_save_count,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 5
+           THEN a.SAVE_COUNT ELSE 0 END) AS day5_save_count,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 6
+           THEN a.SAVE_COUNT ELSE 0 END) AS day6_save_count,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 7
+           THEN a.SAVE_COUNT ELSE 0 END) AS day7_save_count,
+       SUM(a.SAVE_COUNT)                          AS save_count,
+       SUM(a.OPEN_COUNT)                          AS open_count,
+       SUM(a.EXTERNAL_SHARE_COUNT)                AS share_count,
+       SUM(a.favorite_count)                      AS favorite_count
+    FROM ANALYTICS.DBT.CONTENT_ENGAGEMENT_BY_DAY_USER_API_ID as a
+    JOIN latest_curator_decisions as p
+      ON p.content_id = a.content_id
+    WHERE (p.DATE_ADDED - a.HAPPENED_AT) BETWEEN 0 AND 7
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+),
+
+max_counts_by_domain AS (
+    SELECT
+       d.domain_id,
+       d.publisher,
+       max(d.save_count) AS max_save_count,
+       max(d.open_count) AS max_open_count
+    FROM action_counts AS d
+    GROUP BY 1, 2
+)
+
+SELECT
+    c.*,
+    d.max_save_count AS max_domain_saves,
+    d.max_open_count AS max_domain_opens
+ FROM action_counts AS c
+ JOIN max_counts_by_domain AS d
+   ON d.domain_id = c.domain_id
+WHERE c.open_count < c.save_count
+  AND c.publisher <> 'getpocket.com'

--- a/src/flows/prospecting/global_training_full.sql
+++ b/src/flows/prospecting/global_training_full.sql
@@ -47,7 +47,7 @@ backfill_prospects AS (
     JOIN analytics.dbt.content as c
       ON c.resolved_id = p.resolved_id
     WHERE p.feed_id = %(PROSPECT_LEGACY_FEED_ID) s
-      AND DATEDIFF(day, p.time_added, %(SURFACE_START_DATE)s ) BETWEEN 0 AND %(MAX_BACKFILL_AGE) s
+      AND DATEDIFF(day, p.time_added, %(SURFACE_START_DATE)s ) BETWEEN 0 AND %(MAX_BACKFILL_AGE)s
 
 ),
 

--- a/src/flows/prospecting/global_training_inc.sql
+++ b/src/flows/prospecting/global_training_inc.sql
@@ -1,0 +1,110 @@
+WITH latest_approvals AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.approved_corpus_items  -- model with curator approved items
+    WHERE loaded_from = 'PROSPECT'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND DATEDIFF(day, reviewed_corpus_item_created_at, current_date) <= %(MAX_INC_AGE)s
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+),
+
+-- manual submissions to new tab by curators don't have prospect source information which
+-- currently comes from prospect candidate set model.
+latest_manuals AS (
+
+    SELECT
+       content_id,
+       corpus_item_loaded_from as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.scheduled_corpus_items  -- manually submitted items are overwhelmingly scheduled
+    WHERE corpus_item_loaded_from = 'MANUAL'   -- remaining scheduled items are 'recommended'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND DATEDIFF(day, reviewed_corpus_item_created_at, current_date) <= %(MAX_INC_AGE)s -- 1 day
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+latest_rejects AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'denied' as STATUS, -- this is legacy label for rejected prospects to be consistent with backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.rejected_corpus_items  -- model with historic curator decisions
+    WHERE scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND DATEDIFF(day, reviewed_corpus_item_created_at, current_date) <= %(MAX_INC_AGE)s
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+latest_curator_decisions as (
+    select * from latest_approvals
+    union
+    select * from latest_rejects
+    union
+    select * from latest_manuals
+),
+
+
+action_counts as (
+    SELECT
+       a.CONTENT_ID,
+       a.RESOLVED_ID,
+       a.DOMAIN_ID,
+       a.TOP_DOMAIN_NAME AS PUBLISHER,
+       a.WORD_COUNT,
+       a.RESOLVED_URL,
+       a.TITLE,
+       p.TYPE,
+       p.STATUS,
+       p.DATE_ADDED,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) BETWEEN 0 AND 1
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY1_SAVE_COUNT,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 2
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY2_SAVE_COUNT,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 3
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY3_SAVE_COUNT,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 4
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY4_SAVE_COUNT,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 5
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY5_SAVE_COUNT,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 6
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY6_SAVE_COUNT,
+       SUM(CASE WHEN (p.DATE_ADDED - a.HAPPENED_AT) = 7
+           THEN a.SAVE_COUNT ELSE 0 END) AS DAY7_SAVE_COUNT,
+       SUM(a.SAVE_COUNT)                          AS SAVE_COUNT,
+       SUM(a.OPEN_COUNT)                          AS OPEN_COUNT,
+       SUM(a.EXTERNAL_SHARE_COUNT)                AS SHARE_COUNT,
+       SUM(a.favorite_count)                      AS FAVORITE_COUNT
+    FROM ANALYTICS.DBT.CONTENT_ENGAGEMENT_BY_DAY_USER_API_ID as a
+    JOIN latest_curator_decisions as p
+      ON p.content_id = a.content_id
+    WHERE (p.DATE_ADDED - a.HAPPENED_AT) BETWEEN 0 AND 7
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+),
+
+max_counts_by_domain AS (
+    SELECT
+       d.DOMAIN_ID,
+       d.PUBLISHER,
+       max(d.SAVE_COUNT) AS max_save_count,
+       max(d.OPEN_COUNT) AS max_open_count
+    FROM action_counts AS d
+    GROUP BY 1, 2
+)
+
+SELECT
+    c.*,
+    d.max_save_count AS MAX_DOMAIN_SAVES,
+    d.max_open_count AS MAX_DOMAIN_OPENS
+ FROM action_counts AS c
+ JOIN max_counts_by_domain AS d
+   ON d.DOMAIN_ID = c.DOMAIN_ID
+WHERE c.OPEN_COUNT < c.SAVE_COUNT
+  AND c.publisher <> 'getpocket.com'

--- a/src/flows/prospecting/timespent_training_features_flow.py
+++ b/src/flows/prospecting/timespent_training_features_flow.py
@@ -1,0 +1,48 @@
+from prefect import Flow, Parameter, case
+from prefect.tasks.control_flow import merge
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+from global_training_features_flow import DAY_IN_MINUTES, QUERY_PARAMS, check_refresh, \
+    load_query, load_feature_record
+
+FLOW_NAME = get_flow_name(__file__)
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=DAY_IN_MINUTES)) as flow:
+
+    # full_refresh if feature group needs to be rebuilt from scratch, e.g. schema change
+    full_refresh = Parameter("full_refresh", default=False)
+
+    training_feature_group = Parameter("feature group",
+                                       default=f"{config.ENVIRONMENT}-timespent-prospect-modeling-data-v1")
+
+    refresh_query_file = Parameter("refresh_query_file",
+                                   default="timespent_training_full.sql")
+
+    inc_query_file = Parameter("inc_query_file",
+                               default="timespent_training_inc.sql")
+
+    refresh = check_refresh(full_refresh)
+    print(refresh)
+
+    with case(refresh, True):
+        query_r = load_query(refresh_query_file)
+
+    with case(refresh, False):
+        query_i = load_query(inc_query_file)
+
+    query = merge(query_i, query_r)
+
+    reviewed_prospects = PocketSnowflakeQuery()(
+        query=query,
+        data=QUERY_PARAMS,
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DATA_FRAME,
+    )
+
+    load_feature_record(reviewed_prospects, feature_group_name=training_feature_group)
+
+if __name__ == "__main__":
+    flow.run(parameters=dict(full_refresh=False))

--- a/src/flows/prospecting/timespent_training_features_flow.py
+++ b/src/flows/prospecting/timespent_training_features_flow.py
@@ -10,6 +10,7 @@ from global_training_features_flow import DAY_IN_MINUTES, QUERY_PARAMS, check_re
 FLOW_NAME = get_flow_name(__file__)
 
 with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=DAY_IN_MINUTES)) as flow:
+# with Flow(FLOW_NAME) as flow:  # to run in production in pycharm need to disable schedule
 
     # full_refresh if feature group needs to be rebuilt from scratch, e.g. schema change
     full_refresh = Parameter("full_refresh", default=False)

--- a/src/flows/prospecting/timespent_training_full.sql
+++ b/src/flows/prospecting/timespent_training_full.sql
@@ -1,0 +1,174 @@
+
+WITH latest_approvals AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.approved_corpus_items  -- model with historic curator decisions
+    WHERE loaded_from = 'PROSPECT'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND reviewed_corpus_item_created_at >  %(SURFACE_START_DATE)s  -- date when surface started in curation tool
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+-- manual submissions to new tab by curators don't have prospect source information which
+-- currently comes from prospect candidate set model.  we need a scheduled surface which is
+-- only available in the scheduled_corpus_items model for those manual submissions that are
+-- scheduled (in addition to having status recommended)
+latest_manuals AS (
+
+    SELECT
+       content_id,
+       corpus_item_loaded_from as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.scheduled_corpus_items  -- model with historic curator decisions
+    WHERE corpus_item_loaded_from = 'MANUAL'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND reviewed_corpus_item_created_at >  %(SURFACE_START_DATE)s  -- date when surface started in curation tool
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+-- one year of prospects (rejected and approved) prior to the curation tool
+-- NEW_TAB_EN_US migrated to curation tool on 5/31/22
+-- this model includes historical approvals and rejections, airflow model only has approvals
+-- reviewed_corpus_item_prospects_merged doesn't include manual submissions
+backfill_prospects AS (
+
+    SELECT
+        c.content_id,
+        p.type,
+        p.status,
+        DATE(p.time_added) AS DATE_ADDED
+    FROM analytics.dbt_staging.stg_curated_feed_prospects as p
+    JOIN analytics.dbt.content as c
+      on c.resolved_id = p.resolved_id
+    WHERE p.feed_id = %(PROSPECT_LEGACY_FEED_ID)s
+    AND DATEDIFF(day, p.time_added, %(SURFACE_START_DATE)s ) BETWEEN 0 AND %(MAX_BACKFILL_AGE)s
+
+),
+
+
+latest_rejects AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'denied' as STATUS, -- this is legacy label for rejected prospects to be consistent with backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.rejected_corpus_items  -- model with historic curator decisions
+    WHERE scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND reviewed_corpus_item_created_at >= %(SURFACE_START_DATE)s  -- date when surface started in curation tool
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+latest_curator_decisions as (
+    select * from latest_approvals
+    union
+    select * from latest_rejects
+    union
+    select * from backfill_prospects
+    union
+    select * from latest_manuals
+),
+
+action_counts as (
+    SELECT
+       a.content_id,
+       a.RESOLVED_ID,
+       a.DOMAIN_ID,
+       a.TOP_DOMAIN_NAME AS PUBLISHER,
+       a.WORD_COUNT,
+       a.RESOLVED_URL,
+       a.TITLE,
+       p.TYPE,
+       p.STATUS,
+       p.DATE_ADDED,
+       SUM(a.SAVE_COUNT)                          AS save_count,
+       SUM(a.OPEN_COUNT)                          AS open_count,
+       SUM(a.EXTERNAL_SHARE_COUNT)                AS share_count,
+       SUM(a.favorite_count)                      AS favorite_count
+    FROM ANALYTICS.DBT.CONTENT_ENGAGEMENT_BY_DAY as a
+    JOIN latest_curator_decisions as p
+      ON p.content_id = a.content_id
+    WHERE a.HAPPENED_AT between p.DATE_ADDED - 7 and p.DATE_ADDED
+    and a.resolved_id <> 3242033017  -- pocket welcome page
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+),
+
+-- session time is coming from a pageview model and needs to be aggregated by the URL
+-- this only includes time in app on mobile hence the URL associated with reader view
+time_spent_prep as (
+  select
+    r.content_id,
+    r.resolved_id,
+    COUNT(1) AS pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) BETWEEN 0 AND 1
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day1_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 2
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day2_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 3
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day3_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 4
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day4_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 5
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day5_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 6
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day6_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 7
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day7_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) BETWEEN 0 AND 1
+        THEN 1 ELSE 0 END) AS day1_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 2
+        THEN 1 ELSE 0 END) AS day2_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 3
+        THEN 1 ELSE 0 END) AS day3_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 4
+        THEN 1 ELSE 0 END) AS day4_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 5
+        THEN 1 ELSE 0 END) AS day5_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 6
+        THEN 1 ELSE 0 END) AS day6_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 7
+        THEN 1 ELSE 0 END) AS day7_pageviews,
+    SUM(a.TIME_ENGAGED_IN_S) as time_spent_sum
+  from ANALYTICS.DBT.SNOWPLOW_PAGE_VIEWS as a
+  join ANALYTICS.DBT_STAGING.STG_LEGACY_ITEM_ID_TO_GIVEN_URL_MAP as b
+    on TRY_CAST(SPLIT(a.PAGE_URL_PATH, '/')[2]::string as integer) = b.ITEM_ID
+  join action_counts as r
+    on b.resolved_id = r.resolved_id
+  where a.PAGE_URL_PATH like '/read/%%' -- this is how to escape the percent wildcard used for like in a parameterized query
+    and a.TIME_ENGAGED_IN_S > 30        -- more info here https://stackoverflow.com/questions/48777070/using-in-like-clause-of-select-statement-in-python
+    -- read time in seconds is estimated using a reading speed of 265 wpm
+    and a.TIME_ENGAGED_IN_S < (r.word_count::float / 265) * 60 * 1.8  -- drop sessions that are too long
+    and r.date_added BETWEEN DATE(a.began_at) AND DATE(a.began_at) + 7
+    and r.resolved_id <> 3242033017  -- pocket welcome page
+  group by 1, 2
+  )
+
+select
+  p.*,
+  t.pageviews,
+  t.day1_timespent,
+  t.day2_timespent,
+  t.day3_timespent,
+  t.day4_timespent,
+  t.day5_timespent,
+  t.day6_timespent,
+  t.day7_timespent,
+  t.day1_pageviews,
+  t.day2_pageviews,
+  t.day3_pageviews,
+  t.day4_pageviews,
+  t.day5_pageviews,
+  t.day6_pageviews,
+  t.day7_pageviews,
+  t.time_spent_sum as total_timespent
+from action_counts as p
+join time_spent_prep as t
+  on p.content_id = t.content_id

--- a/src/flows/prospecting/timespent_training_inc.sql
+++ b/src/flows/prospecting/timespent_training_inc.sql
@@ -1,0 +1,152 @@
+
+WITH latest_approvals AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.approved_corpus_items  -- model with historic curator decisions
+    WHERE loaded_from = 'PROSPECT'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND DATEDIFF(day, reviewed_corpus_item_created_at, current_date) <= %(MAX_INC_AGE)s
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+-- manual submissions to new tab by curators don't have prospect source information which
+-- currently comes from prospect candidate set model.  we need a scheduled surface which is
+-- only available in the scheduled_corpus_items model for those manual submissions that are
+-- scheduled (in addition to having status recommended)
+latest_manuals AS (
+
+    SELECT
+       content_id,
+       corpus_item_loaded_from as TYPE,
+       'approved' as STATUS,  -- collapsing recommendation and corpus to 'approved' as in backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.scheduled_corpus_items  -- model with historic curator decisions
+    WHERE corpus_item_loaded_from = 'MANUAL'
+    AND scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND DATEDIFF(day, reviewed_corpus_item_created_at, current_date) <= %(MAX_INC_AGE)s
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+latest_rejects AS (
+
+    SELECT
+       content_id,
+       prospect_source as TYPE,
+       'denied' as STATUS, -- this is legacy label for rejected prospects to be consistent with backfill
+       DATE(reviewed_corpus_item_created_at) AS DATE_ADDED
+    FROM analytics.dbt.rejected_corpus_items  -- model with historic curator decisions
+    WHERE scheduled_surface_id = %(PROSPECT_SURFACE_GUID)s  -- (e.g. en-US/scheduled_surface_id='NEW_TAB_EN_US')
+    AND DATEDIFF(day, reviewed_corpus_item_created_at, current_date) <= %(MAX_INC_AGE)s
+    qualify row_number() over (partition by content_id order by reviewed_corpus_item_created_at desc) = 1
+
+),
+
+latest_curator_decisions as (
+    select * from latest_approvals
+    union
+    select * from latest_rejects
+    union
+    select * from latest_manuals
+),
+
+action_counts as (
+    SELECT
+       a.content_id,
+       a.RESOLVED_ID,
+       a.DOMAIN_ID,
+       a.TOP_DOMAIN_NAME AS PUBLISHER,
+       a.WORD_COUNT,
+       a.RESOLVED_URL,
+       a.TITLE,
+       p.TYPE,
+       p.STATUS,
+       p.DATE_ADDED,
+       SUM(a.SAVE_COUNT)                          AS save_count,
+       SUM(a.OPEN_COUNT)                          AS open_count,
+       SUM(a.EXTERNAL_SHARE_COUNT)                AS share_count,
+       SUM(a.favorite_count)                      AS favorite_count
+    FROM ANALYTICS.DBT.CONTENT_ENGAGEMENT_BY_DAY as a
+    JOIN latest_curator_decisions as p
+      ON p.content_id = a.content_id
+    WHERE a.HAPPENED_AT between p.DATE_ADDED - 7 and p.DATE_ADDED
+    and a.resolved_id <> 3242033017  -- pocket welcome page
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+),
+
+-- session time is coming from a pageview model and needs to be aggregated by the URL
+-- this only includes time in app on mobile hence the URL associated with reader view
+time_spent_prep as (
+  select
+    r.content_id,
+    r.resolved_id,
+    COUNT(1) AS pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) BETWEEN 0 AND 1
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day1_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 2
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day2_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 3
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day3_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 4
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day4_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 5
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day5_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 6
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day6_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 7
+        THEN a.TIME_ENGAGED_IN_S ELSE 0 END) AS day7_timespent,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) BETWEEN 0 AND 1
+        THEN 1 ELSE 0 END) AS day1_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 2
+        THEN 1 ELSE 0 END) AS day2_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 3
+        THEN 1 ELSE 0 END) AS day3_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 4
+        THEN 1 ELSE 0 END) AS day4_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 5
+        THEN 1 ELSE 0 END) AS day5_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 6
+        THEN 1 ELSE 0 END) AS day6_pageviews,
+    SUM(CASE WHEN (r.DATE_ADDED - DATE(a.began_at)) = 7
+        THEN 1 ELSE 0 END) AS day7_pageviews,
+    SUM(a.TIME_ENGAGED_IN_S) as time_spent_sum
+  from ANALYTICS.DBT.SNOWPLOW_PAGE_VIEWS as a
+  join ANALYTICS.DBT_STAGING.STG_LEGACY_ITEM_ID_TO_GIVEN_URL_MAP as b
+    on TRY_CAST(SPLIT(a.PAGE_URL_PATH, '/')[2]::string as integer) = b.ITEM_ID
+  join action_counts as r
+    on b.resolved_id = r.resolved_id
+  where a.PAGE_URL_PATH like '/read/%%' -- this is how to escape the percent wildcard used for like in a parameterized query
+    and a.TIME_ENGAGED_IN_S > 30        -- more info here https://stackoverflow.com/questions/48777070/using-in-like-clause-of-select-statement-in-python
+    -- read time in seconds is estimated using a reading speed of 265 wpm
+    and a.TIME_ENGAGED_IN_S < (r.word_count::float / 265) * 60 * 1.8  -- drop sessions that are too long
+    and r.date_added BETWEEN DATE(a.began_at) AND DATE(a.began_at) + 7
+    and r.resolved_id <> 3242033017  -- pocket welcome page
+  group by 1, 2
+  )
+
+select
+  p.*,
+  t.pageviews,
+  t.day1_timespent,
+  t.day2_timespent,
+  t.day3_timespent,
+  t.day4_timespent,
+  t.day5_timespent,
+  t.day6_timespent,
+  t.day7_timespent,
+  t.day1_pageviews,
+  t.day2_pageviews,
+  t.day3_pageviews,
+  t.day4_pageviews,
+  t.day5_pageviews,
+  t.day6_pageviews,
+  t.day7_pageviews,
+  t.time_spent_sum as total_timespent
+from action_counts as p
+join time_spent_prep as t
+  on p.content_id = t.content_id


### PR DESCRIPTION
## Goal
Goal here is to create flows that will update training data that is logged to feature groups.  The training data is used to retrain models that create prospecting candidate sets using global counts features and timespent features combined with publisher data and our content vectors stored in the vector store.

## Implementation Decisions

There are two flows: one for the global training data and the other for the timespent training data.  Each uses a `refresh` parameter that is set manually in the flow script to determine whether they are run incrementally (default) or to fully rebuild the training sets with backfill (pre-curation tool) data.  

The parameter governs which query is executed in snowflake to obtain data to be added to the feature group.  

There are separate feature groups for the two feature sets, both keyed on `resolved_id`.  We can change the schema later to key on a URL or corpus-api identifier.

## References


