### PR TITLE
Fix SQS permission issue when writing candidate sets

### DIFF
--- a/.aws/src/FlowTaskRole.ts
+++ b/.aws/src/FlowTaskRole.ts
@@ -100,7 +100,7 @@ export class FlowTaskRole extends Resource {
    */
   private getDataProductsSqsWriteAccess(): iam.DataAwsIamPolicyDocumentStatement {
     return {
-      actions: ['sqs:SendMessage'],
+      actions: ['sqs:SendMessage', 'sqs:GetQueueUrl'],
       resources: [
         'arn:aws:sqs:*:*:RecommendationAPI-*',
         'arn:aws:sqs:*:*:ProspectAPI-*',


### PR DESCRIPTION
## Goal
Fix an [SQS permission issue](https://cloud.prefect.io/pocket/flow-run/4983db31-c6a8-4282-ae6a-364d82d7706d?logs): 
> An error occurred (AWS.SimpleQueueService.NonExistentQueue) when calling the **GetQueueUrl** operation: The specified queue does not exist or you do not have access to it.



## Implementation Decisions
- This permission should arguable also be part of the shared read-only policy.

## References

Slack thread:
* https://pocket.slack.com/archives/C02JZ4TRF0S/p1658955481215259

Documentation:
* [AWS SQS IAM reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsqs.html)
