### PR TITLE
Curated Corpus Topic Candidate sets to Feature store [HS-113]

### DIFF
--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -18,8 +18,8 @@ def validate_corpus_items(corpus_items: List[Dict]):
 
     assert len(corpus_items) >= min_item_count
     assert all(list(corpus_item.keys()) == expected_keys for corpus_item in corpus_items)
-    assert all(corpus_item['ID'] for corpus_item in corpus_items)
-    assert all(corpus_item['TOPIC'] for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['ID'], str) for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['TOPIC'], str) for corpus_item in corpus_items)
 
     return corpus_items
 

--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -18,8 +18,8 @@ def validate_corpus_items(corpus_items: List[Dict]):
 
     assert len(corpus_items) >= min_item_count
     assert all(list(corpus_item.keys()) == expected_keys for corpus_item in corpus_items)
-    assert all(isinstance(corpus_item['ID'], str) for corpus_item in corpus_items)
-    assert all(isinstance(corpus_item['TOPIC'], str) for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['ID'], str) and corpus_item['ID'] != '' for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['TOPIC'], str) and corpus_item['TOPIC'] != '' for corpus_item in corpus_items)
 
     return corpus_items
 

--- a/src/flows/recommendation_api/topics_flow.py
+++ b/src/flows/recommendation_api/topics_flow.py
@@ -1,5 +1,5 @@
 from prefect import Flow, Parameter, unmapped, task
-
+from prefect.executors import LocalDaskExecutor
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
 from common_tasks.corpus_candidate_set import (
     create_corpus_candidate_set_record,
@@ -12,47 +12,48 @@ from utils.flow import get_flow_name, get_interval_schedule
 
 FLOW_NAME = get_flow_name(__file__)
 
-CORPUS_CANDIDATE_SET_ID = 'a765b8ab-9631-4046-9d2e-8706324efc96'
-
 # Export approved corpus items by language and recency
 EXPORT_CORPUS_ITEMS_SQL = """
-SELECT *
+SELECT 
+    approved_corpus_item_external_id as ID, 
+    topic
 FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
-WHERE APPROVED_AT >= DATE_ADD('day', -90, CURRENT_DATE())
-AND TOPIC = %(topic)s
-AND LANGUAGE = 'en'
+WHERE REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD('day', -90, current_timestamp())
+AND TOPIC = %(CORPUS_TOPIC_ID)s
+AND LANGUAGE = 'EN'
 """
 
 GET_TOPICS_SQL = """
-SELECT id, topic 
-FROM "ANALYTICS"."DBT"."CORPUS_CANDIDATE_SETS"
+SELECT 
+    curated_corpus_candidate_set_id, 
+    corpus_topic_id
+FROM analytics.dbt.static_corpus_candidate_set_topics
 """
 
 @task()
-def get_topic_ids(topics):
-    return [i['corpus_candidate_set_id'] for i in topics]
+def get_candidate_set_ids(topics):
+    return [i['CURATED_CORPUS_CANDIDATE_SET_ID'] for i in topics]
 
-
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type = OutputType.DICT
     )
 
-    topics = query(query=GET_TOPICS_SQL, output_type=OutputType.DICT)
-    topic_ids = get_topic_ids(topics)
+    topics = query(query=GET_TOPICS_SQL)
+
+    candidate_set_ids = get_candidate_set_ids(topics)
 
     topic_corpus_items = query.map(data=topics, query=unmapped(EXPORT_CORPUS_ITEMS_SQL))
 
     topic_corpus_items = validate_corpus_items.map(topic_corpus_items)
 
     feature_group_record = create_corpus_candidate_set_record.map(
-        id=topic_ids,
+        id=candidate_set_ids,
         corpus_items=topic_corpus_items,
     )
-    load_feature_record(feature_group_record, feature_group_name=feature_group)
+    load_feature_record.map(feature_group_record, feature_group_name=unmapped(feature_group))
 
 if __name__ == "__main__":
     flow.run()
-
-

--- a/src/flows/recommendation_api/topics_flow.py
+++ b/src/flows/recommendation_api/topics_flow.py
@@ -15,8 +15,8 @@ FLOW_NAME = get_flow_name(__file__)
 # Export approved corpus items by language and recency
 EXPORT_CORPUS_ITEMS_SQL = """
 SELECT 
-    approved_corpus_item_external_id as ID, 
-    topic
+    approved_corpus_item_external_id as "ID", 
+    topic as "TOPIC"
 FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
 WHERE REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD('day', -90, current_timestamp())
 AND TOPIC = %(CORPUS_TOPIC_ID)s
@@ -25,8 +25,8 @@ AND LANGUAGE = 'EN'
 
 GET_TOPICS_SQL = """
 SELECT 
-    curated_corpus_candidate_set_id, 
-    corpus_topic_id
+    curated_corpus_candidate_set_id as "CURATED_CORPUS_CANDIDATE_SET_ID", 
+    corpus_topic_id as "CORPUS_TOPIC_ID"
 FROM analytics.dbt.static_corpus_candidate_set_topics
 """
 
@@ -47,11 +47,11 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalD
 
     topic_corpus_items = query.map(data=topics, query=unmapped(EXPORT_CORPUS_ITEMS_SQL))
 
-    topic_corpus_items = validate_corpus_items.map(topic_corpus_items)
+    valid_topic_corpus_items = validate_corpus_items.map(topic_corpus_items)
 
     feature_group_record = create_corpus_candidate_set_record.map(
         id=candidate_set_ids,
-        corpus_items=topic_corpus_items,
+        corpus_items=valid_topic_corpus_items,
     )
     load_feature_record.map(feature_group_record, feature_group_name=unmapped(feature_group))
 

--- a/src/flows/recommendation_api/topics_flow.py
+++ b/src/flows/recommendation_api/topics_flow.py
@@ -1,0 +1,58 @@
+from prefect import Flow, Parameter, unmapped, task
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from common_tasks.corpus_candidate_set import (
+    create_corpus_candidate_set_record,
+    load_feature_record,
+    feature_group,
+    validate_corpus_items,
+)
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+
+FLOW_NAME = get_flow_name(__file__)
+
+CORPUS_CANDIDATE_SET_ID = 'a765b8ab-9631-4046-9d2e-8706324efc96'
+
+# Export approved corpus items by language and recency
+EXPORT_CORPUS_ITEMS_SQL = """
+SELECT *
+FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
+WHERE APPROVED_AT >= DATE_ADD('day', -90, CURRENT_DATE())
+AND TOPIC = %(topic)s
+AND LANGUAGE = 'en'
+"""
+
+GET_TOPICS_SQL = """
+SELECT id, topic 
+FROM "ANALYTICS"."DBT"."CORPUS_CANDIDATE_SETS"
+"""
+
+@task()
+def get_topic_ids(topics):
+    return [i['corpus_candidate_set_id'] for i in topics]
+
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+    query = PocketSnowflakeQuery(
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+    )
+
+    topics = query(query=GET_TOPICS_SQL, output_type=OutputType.DICT)
+    topic_ids = get_topic_ids(topics)
+
+    topic_corpus_items = query.map(data=topics, query=unmapped(EXPORT_CORPUS_ITEMS_SQL))
+
+    topic_corpus_items = validate_corpus_items.map(topic_corpus_items)
+
+    feature_group_record = create_corpus_candidate_set_record.map(
+        id=topic_ids,
+        corpus_items=topic_corpus_items,
+    )
+    load_feature_record(feature_group_record, feature_group_name=feature_group)
+
+if __name__ == "__main__":
+    flow.run()
+
+

--- a/src/test/common_tasks/test_corpus_candidate_set.py
+++ b/src/test/common_tasks/test_corpus_candidate_set.py
@@ -34,6 +34,7 @@ def test_validate_corpus_items_returns_corpus_items(corpus_items_100):
         ([{'id': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a'}]),                       # Must contain 'TOPIC'
         ([{'id': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': 'BUSINESS'}]),  # 'ID' key is case-sensitive
         ([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'Topic': 'BUSINESS'}]),  # 'TOPIC' key is case-sensitive
+        ([{'ID': 1234, 'TOPIC': 'BUSINESS'}]),                                      # ID must be a string
         ([{'ID': '', 'TOPIC': 'BUSINESS'}]),                                      # 'ID' key must be non-empty
         ([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': ''}]),          # 'TOPIC' must be non-empty
         ([{'ID': 'c9bf9e57-1685-4c89-bafb-ff5af830be8a', 'TOPIC': 'BUSINESS', 'FOO': 'BAR'}]),  # No other keys expected


### PR DESCRIPTION
## Goal

To generate recently Curated Corpus Topic Candidate item sets and ingest into Sagemaker Feature store

## Implementation Decisions

- `APPROVED_CORPUS_ITEMS` is queried for recent approvals (last 90 days) for corpus items
- The sets of Corpus topic item candidates are ingested to the `corpus-candidate-sets` Feature group
- Additional updates: Added/updated the test for corpus item IDs to be string (to prevent the old numeric IDs from being ingested)

JIRA ticket:
* [HS-113](https://getpocket.atlassian.net/browse/HS-113)

