### PR TITLE
Generate and ingest curated topic candidate sets (legacy) to SQS [HS-125]

### DIFF
--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -23,6 +23,18 @@ def validate_corpus_items(corpus_items: List[Dict]):
 
     return corpus_items
 
+@task()
+def validate_candidate_items(corpus_items: List[Dict]):
+    min_item_count = 1
+    expected_keys = ['ID', 'PUBLISHER']
+
+    assert len(corpus_items) >= min_item_count
+    assert all(list(corpus_item.keys()) == expected_keys for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['ID'], int) and corpus_item['ID'] != None for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['PUBLISHER'], str) and corpus_item['PUBLISHER'] != '' for corpus_item in corpus_items)
+
+    return corpus_items
+
 
 @task()
 def create_corpus_candidate_set_record(

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -1,0 +1,70 @@
+from typing import List
+from prefect import Flow, Parameter, unmapped, task
+from prefect.executors import LocalDaskExecutor
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from common_tasks.corpus_candidate_set import (
+    validate_candidate_items,
+)
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
+
+FLOW_NAME = get_flow_name(__file__)
+
+# Export approved candidate items by language and recency
+EXPORT_CORPUS_ITEMS_SQL = """
+SELECT 
+    a.resolved_id as "ID", 
+    c.top_domain_name as "PUBLISHER"
+FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS" as a
+JOIN "ANALYTICS"."DBT".content as c ON c.content_id = a.content_id
+WHERE REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD('day', -90, current_timestamp())
+AND a.TOPIC = %(CORPUS_TOPIC_ID)s
+AND a.LANGUAGE = 'EN'
+"""
+
+GET_TOPICS_SQL = """
+select 
+    CURATEDCANDIDATEID as "CURATED_CORPUS_CANDIDATE_SET_ID",
+    CORPUS_TOPIC_ID as "CORPUS_TOPIC_ID"    
+from "ANALYTICS"."DBT"."STATIC_TOPIC_MAP_GUIDS" as m
+join "ANALYTICS"."DBT"."STATIC_TOPIC_LIST" as t on t.id = m.id
+where CURATEDCANDIDATEID is not null and CORPUS_TOPIC_ID is not null
+"""
+
+@task()
+def get_candidate_set_ids(topics):
+    return [i['CURATED_CORPUS_CANDIDATE_SET_ID'] for i in topics]
+
+@task()
+def transform_to_candidates(records: dict) -> List[RecommendationCandidate]:
+    return [RecommendationCandidate(
+        item_id=rec["ID"],
+        publisher=rec["PUBLISHER"],
+        feed_id=int(NewTabFeedID.en_US)
+    ) for rec in records]
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+    query = PocketSnowflakeQuery(
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type = OutputType.DICT
+    )
+
+    # Fetch a list of Topic Candidates
+    topics = query(query=GET_TOPICS_SQL)
+
+    candidate_set_ids = get_candidate_set_ids(topics)
+
+    # Fetch the most recent Topic Candidate Items
+    topic_candidate_items = query.map(data=topics, query=unmapped(EXPORT_CORPUS_ITEMS_SQL))
+
+    # Fetch the most recent Topic Candidate Items
+    valid_topic_candidate_items = validate_candidate_items.map(topic_candidate_items)
+
+    # Write Topic Candidate sets to SQS
+    candidates = transform_to_candidates.map(valid_topic_candidate_items)
+    put_results.map(candidate_set_ids, candidates, curated=unmapped(True))
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -57,7 +57,7 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalD
     # Fetch the most recent Topic Candidate Items
     topic_candidate_items = query.map(data=topics, query=unmapped(EXPORT_CORPUS_ITEMS_SQL))
 
-    # Fetch the most recent Topic Candidate Items
+    # Validate Topic Candidate Items
     valid_topic_candidate_items = validate_candidate_items.map(topic_candidate_items)
 
     # Write Topic Candidate sets to SQS

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -21,6 +21,8 @@ JOIN "ANALYTICS"."DBT".content as c ON c.content_id = a.content_id
 WHERE REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD('day', -90, current_timestamp())
 AND a.TOPIC = %(CORPUS_TOPIC_ID)s
 AND a.LANGUAGE = 'EN'
+order by REVIEWED_CORPUS_ITEM_UPDATED_AT desc
+limit 45
 """
 
 GET_TOPICS_SQL = """

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -14,7 +14,7 @@ FLOW_NAME = get_flow_name(__file__)
 # Export approved candidate items by language and recency
 EXPORT_CORPUS_ITEMS_SQL = """
 SELECT 
-    a.resolved_id as "ID", 
+    a.resolved_id as "ID",
     c.top_domain_name as "PUBLISHER"
 FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS" as a
 JOIN "ANALYTICS"."DBT".content as c ON c.content_id = a.content_id
@@ -25,16 +25,14 @@ AND a.LANGUAGE = 'EN'
 
 GET_TOPICS_SQL = """
 select 
-    CURATEDCANDIDATEID as "CURATED_CORPUS_CANDIDATE_SET_ID",
-    CORPUS_TOPIC_ID as "CORPUS_TOPIC_ID"    
-from "ANALYTICS"."DBT"."STATIC_TOPIC_MAP_GUIDS" as m
-join "ANALYTICS"."DBT"."STATIC_TOPIC_LIST" as t on t.id = m.id
-where CURATEDCANDIDATEID is not null and CORPUS_TOPIC_ID is not null
+    LEGACY_CURATED_CORPUS_CANDIDATE_SET_ID as "LEGACY_CURATED_CORPUS_CANDIDATE_SET_ID",
+    CORPUS_TOPIC_ID as "CORPUS_TOPIC_ID"
+from "ANALYTICS"."DBT"."STATIC_CORPUS_CANDIDATE_SET_TOPICS"
 """
 
 @task()
 def get_candidate_set_ids(topics):
-    return [i['CURATED_CORPUS_CANDIDATE_SET_ID'] for i in topics]
+    return [i['LEGACY_CURATED_CORPUS_CANDIDATE_SET_ID'] for i in topics]
 
 @task()
 def transform_to_candidates(records: dict) -> List[RecommendationCandidate]:


### PR DESCRIPTION
## Goal

Generate and ingest curated topic candidate sets (legacy) to SQS
Benefits:
1. Consolidate the candidate set generation processes in a single flow using the Prefect service (reduces tech debit and code duplication in Metaflow)
2. Integrate Coronavirus (previously a special case) into a single flow with necessary metadata made available as a data model

## Deployment
- [ ] Carolyn has signed off on the changes in candidate sets ([Slack thread](https://pocket.slack.com/archives/C03EYPH93GU/p1659641383324719))

## Implementation Decisions

- Candidate set metadata previously imported and made available as data models are being used
- Curated Candidate set items are also available in the previously built data models making it possible to fetch the necessary data

### Observation:
The `STATIC_TOPIC_MAP_GUIDS` candidate set metadata previously imported from the static json file [topic_map_guids.json](https://github.com/Pocket/dl-metaflow-jobs/blob/main/jobs/resources/topic_map_guids.json#L28-L37) appears to have missing metadata `curatedCandidateID`, `algorithmicCandidateID` and `curatedNotNewTabCandidateID` for the `CORONAVIRUS` topic. For this PR we using the `curatedCandidateID` values.
We would need to update the seed data for the `CORONAVIRUS` topic for the missing values.
(Note: I have applied the [where CURATEDCANDIDATEID is not null and CORPUS_TOPIC_ID is not null](https://github.com/Pocket/data-flows/compare/legacy_topic_flow?expand=1#diff-749c58c9a3c210f4a04a17e86d299b8c58339ce62f6a9c26a1d41a35d1f3e556R32) filter to skip missing data)

## References

JIRA ticket:
* [HS-125](https://getpocket.atlassian.net/browse/HS-125)

### Test run in AWS Dev
The test run results using the AWS Dev account to send to the `RecommendationAPI-Dev` SQS and eventually to DynamoDB table `RECAPI-Dev-CandidateSets` is available [here](https://us-east-1.console.aws.amazon.com/dynamodbv2/home?region=us-east-1#item-explorer?initialTagKey=&table=RECAPI-Dev-CandidateSets)