### PR TITLE
Create new session for each thread using boto3

### DIFF
--- a/src/api_clients/sqs.py
+++ b/src/api_clients/sqs.py
@@ -110,7 +110,8 @@ def put_results(candidate_set_id: str,
         raise AssertionError(f"Invalid expiry set: {expires_in_s=}")
 
     message = json.dumps(candidate_set.dict())
-    sqs = boto3.resource('sqs')
+    boto3_session = boto3.session.Session()  # Each thread needs its own boto3 session
+    sqs = boto3_session.resource('sqs')
     queue = sqs.get_queue_by_name(QueueName=sqs_queue_name)
     logger.info(f'Sent {len(candidates)} candidates from {candidate_set_id}')
     sqs_result = queue.send_message(MessageBody=message)


### PR DESCRIPTION
## Goal
Fix exception in [exception in legacy topics flow](https://cloud.prefect.io/pocket/task-run/102180ca-2a1c-4a13-9ac8-e8c574d9bd99?logs&schematic=6db65bd3-9d54-4a41-b659-b95926013dac), caused by re-using the default boto3 session across multiple threads. boto3 is [not thread-safe](https://stackoverflow.com/questions/52675027/why-do-i-sometimes-get-key-error-using-sqs-client).

> KeyError: 'endpoint_resolver'

## References

Error alert:
* https://pocket.slack.com/archives/C02KH5U7G79/p1661159367514759