### PR TITLE
Change task size to workaround ECS incident

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -27,8 +27,8 @@ const prefect = {
   flowTask: {
     // See the documentation below for valid values for CPU and memory:
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu
-    cpu: 4096, // 4096 = 4 vCPU
-    memory: 30720, // 30720 = 30GB
+    cpu: 1024, // 1024 = 1vCPU, 4096 = 4 vCPU
+    memory: 8192, // available memory in MB
     dataLearningBucketName: isDev
       ? 'pocket-data-learning-dev'
       : 'pocket-data-learning',


### PR DESCRIPTION
## Goal
ECS is having an active incident in US-East-1 where it fails to create instances with 2vCPU or 4vCPU. Switch to 1vCPU (temporarily) to allow flows to run again.

## References

Slack thread:
* https://pocket.slack.com/archives/C02JZ4TRF0S/p1661383050168019?thread_ts=1661376601.306469&cid=C02JZ4TRF0S

AWS incident:
* https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=arn:aws:health:us-east-1::event/ECS/AWS_ECS_API_ISSUE/AWS_ECS_API_ISSUE_b4a822f3-ad73-5de8-954f-a5d5a27c0f71&eventTab=details
