### PR TITLE
User impression flow updates

### DIFF
--- a/src/flows/recommendation_api/user_impressions_flow.py
+++ b/src/flows/recommendation_api/user_impressions_flow.py
@@ -13,41 +13,35 @@ from utils.flow import get_flow_name
 FLOW_NAME = get_flow_name(__file__)
 
 BASE_QUERY = """
-WITH 
-prep as (
+WITH prep AS (
   SELECT
     a.HASHED_USER_ID,
     a.CONTENT_ID,
     c.RESOLVED_ID,
-    MAX(a.IMPRESSION_AGE) as max_impression_age,
-    SUM(a.IMPRESSION_COUNT) as total_imprs,
-    MAX(a.HAPPENED_AT_DAY) as HAPPENED_AT
+    current_date - a.HAPPENED_AT_DAY as first_impression_age,
+    MIN(a.IMPRESSION_AGE) as last_impression_age,
+    SUM(a.IMPRESSION_COUNT) as total_impressions,
+    MAX(a.HAPPENED_AT_DAY) as last_impressed_date
   FROM ANALYTICS.DBT.FIRST_IMPRESSED_AGE as a
   JOIN ANALYTICS.DBT.CONTENT AS c
     ON c.CONTENT_ID = a.CONTENT_ID
-  WHERE CURRENT_DATE - 1 <= a.TIME_ADDED
-  GROUP BY 1, 2, 3
+  WHERE CURRENT_DATE - %(AGG_WINDOW_DAYS)s <= a.TIME_ADDED  -- all imprs in the last 3 weeks
+  GROUP BY 1, 2, 3, 4
   )
   
 SELECT
-    u.USER_ID,
-    p.HAPPENED_AT AS UPDATED_AT,
+    p.HASHED_USER_ID,
+    current_date AS UPDATED_AT,
     ('[' || LISTAGG(DISTINCT p.RESOLVED_ID, ',') || ']') AS RESOLVED_IDS
 FROM prep as p
-JOIN ANALYTICS.DBT.USERS as u
-  ON p.HASHED_USER_ID = u.HASHED_USER_ID
-WHERE ((p.max_impression_age > %(MAX_AGE)s) OR (p.total_imprs > %(MAX_IMPRS)s))
-  AND CURRENT_DATE = p.HAPPENED_AT
-GROUP BY 1, 2
+WHERE ((p.first_impression_age > %(MAX_IMPR_AGE)s) OR (p.total_impressions > %(MAX_IMPRS)s))  -- filter based on time since 1st impr
+GROUP BY 1, 2                                                                                 -- or total imprs
 """
 
 
 @task
 def transform_user_impressions_df(df: pd.DataFrame) -> pd.DataFrame:
-    df = df.rename(columns={"USER_ID": "user_id",
-                            "RESOLVED_IDS": "resolved_ids",
-                            "UPDATED_AT": "updated_at"}).astype({"user_id": int})
-    df["updated_at"] = df.updated_at.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    df["UPDATED_AT"] = df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
     return df
 
 
@@ -60,20 +54,22 @@ def load_feature_group(df: pd.DataFrame, feature_group_name):
     feature_group = FeatureGroup(name=feature_group_name, sagemaker_session=feature_store_session)
     feature_group.ingest(df, max_workers=4, max_processes=4, wait=True)
 
-# Schedule to run every hour
+# Schedule to run every day
 if config.ENVIRONMENT == config.ENV_PROD:
-    schedule = IntervalSchedule(interval=datetime.timedelta(days=1))
+        schedule = IntervalSchedule(interval=datetime.timedelta(days=1))
 else:
     schedule = None
 
+schedule = None
+
 with Flow(FLOW_NAME, schedule=schedule) as flow:
-    feature_group = Parameter("feature group", default="user-impressions")
+    feature_group = Parameter("feature group", default=f"{config.ENVIRONMENT}-user-impressions-v1")
     max_impr_age = Parameter("max impression age", default=6)
     max_impr_count = Parameter("max impression count", default=12)
 
     snowflake_result = PocketSnowflakeQuery()(
         query=BASE_QUERY,
-        data={"MAX_AGE": max_impr_age, "MAX_IMPRS": max_impr_count}
+        data={"MAX_IMPR_AGE": max_impr_age, "MAX_IMPRS": max_impr_count, "AGG_WINDOW_DAYS": 21}
     )
 
     transformed_df = transform_user_impressions_df(snowflake_result)


### PR DESCRIPTION
## Goal
There were a bunch of recent failures with this flow so @mmiermans and I took another pass at it today.

## Implementation Decisions
 
The main change was to update the impression age measured to list items to be filtered.  Previously we were only updating the list if the item was impressed that day.  This is probably not the desired behavior since we were not concatenating the previous list with the new items.  In this PR, the attempt is to first look at all the impressions in the last 21 days.  These impression events are aggregated by (user, content_id) pair.  The impression age is computed as the difference between  the **current date** and the first time the user impressed the items instead of the most recent time the user impressed the item and the last time the user impressed the item.  

I am not sure this update to the feature group can be done incrementally as we had tried before for the reason that each day, all items the user has impressed increase in impression age, regardless of whether the user impressed them today.  


Small changes were made to change the feature group name to align with our more recent conventions.  I also changed from keying on the user ID to the hashed user ID which is also a new pattern.
