### PR TITLE
adding lifehacks corpus slate

### DIFF
--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -21,7 +21,8 @@ JOIN "ANALYTICS"."DBT".content as c ON c.content_id = a.content_id
 WHERE REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD('day', -90, current_timestamp())
 AND a.TOPIC = %(CORPUS_TOPIC_ID)s
 AND a.LANGUAGE = 'EN'
-order by REVIEWED_CORPUS_ITEM_UPDATED_AT desc
+AND a.CORPUS_REVIEW_STATUS = 'recommendation'
+order by a.REVIEWED_CORPUS_ITEM_UPDATED_AT desc
 limit 45
 """
 

--- a/src/flows/recommendation_api/lifehacks_flow.py
+++ b/src/flows/recommendation_api/lifehacks_flow.py
@@ -1,0 +1,64 @@
+from typing import List
+from prefect import Flow, task
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from common_tasks.corpus_candidate_set import (
+    create_corpus_candidate_set_record,
+    load_feature_record,
+    feature_group,
+    validate_corpus_items,
+)
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+FLOW_NAME = get_flow_name(__file__)
+
+CURATED_LIFEHACKS_CANDIDATE_SET_ID = "da9cb7a1-3a34-4211-b918-73819a5586c8"
+
+# Export approved corpus items by language and recency
+EXPORT_LIFEHACKS_ITEMS_SQL = """
+SELECT 
+    approved_corpus_item_external_id as "ID", 
+    topic as "TOPIC"
+FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
+WHERE REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD("day", %(MAX_AGE_DAYS)s, current_timestamp())
+AND TOPIC IN (%(CORPUS_TOPIC_LIST)s)
+AND CORPUS_REVIEW_STATUS = 'recommendation'
+AND LANGUAGE = 'EN'
+ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
+"""
+
+@task()
+def transform_to_corpus_items(records: dict) -> List[dict]:
+    # corpus candidate sets don't yet include publisher information
+    return [
+        {'ID': rec['ID'], 'TOPIC': rec['TOPIC']}
+        for rec in records]
+
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+
+    # query snowflake for items from pocket hits
+    records = PocketSnowflakeQuery()(
+        query=EXPORT_LIFEHACKS_ITEMS_SQL,
+        data={
+            "MAX_AGE_DAYS": -30,
+            "CORPUS_TOPIC_LIST": ['SELF_IMPROVEMENT','CAREER','HEALTH_FITNESS','PERSONAL_FINANCE']
+        },
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DICT,
+    )
+
+    # create candidate set
+    corpus_items = transform_to_corpus_items(records)
+    corpus_items = validate_corpus_items(corpus_items)
+    feature_group_record = create_corpus_candidate_set_record(
+        id=CURATED_LIFEHACKS_CANDIDATE_SET_ID,
+        corpus_items=corpus_items
+    )
+
+    # load candidate set into feature group
+    load_feature_record(feature_group_record, feature_group_name=feature_group)
+
+if __name__ == "__main__":
+    flow.run()


### PR DESCRIPTION
## Goal

1. Create a lifehacks corpus slate that combines recommended items from topics: Self Improvement, Career, Health, and Personal Finance.
2. Change single topic slates to include only `recommended` items

I changed the `legacy_topics_flow.py` scripts which is what I assume powers the explore pages.  I am leaving the curated corpus slates that power in `topics_flow.py` as is pending further discussion with editorial.  These I am assuming power web home.

## References 

[slack thread](https://pocket.slack.com/archives/C03EYPH93GU/p1661969270926589)