### PR TITLE
adding length based curated candidate generation flows

### DIFF
--- a/src/flows/recommendation_api/lifehacks_flow.py
+++ b/src/flows/recommendation_api/lifehacks_flow.py
@@ -37,7 +37,7 @@ def transform_to_corpus_items(records: dict) -> List[dict]:
 
 with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
 
-    # query snowflake for items from pocket hits
+    # query snowflake for items from lifehacks topic set
     records = PocketSnowflakeQuery()(
         query=EXPORT_LIFEHACKS_ITEMS_SQL,
         data={

--- a/src/flows/recommendation_api/longreads_flow.py
+++ b/src/flows/recommendation_api/longreads_flow.py
@@ -13,7 +13,7 @@ from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)
 
-CURATED_LONGREADS_CANDIDATE_SET_ID_EN = "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6"
+CURATED_LONGREADS_CANDIDATE_SET_ID_EN = "dacc55ea-db8d-4858-a51d-e1c78298337e"
 CURATED_LONGREADS_CANDIDATE_SET_ID_DE = "cff478b9-301e-47cb-accf-ef2fe84ef17a"
 
 # Export approved corpus items by language and recency

--- a/src/flows/recommendation_api/longreads_flow.py
+++ b/src/flows/recommendation_api/longreads_flow.py
@@ -34,11 +34,11 @@ LIMIT 90
 """
 
 @task()
-def transform_to_candidates(records: dict, feed_id: NewTabFeedID) -> List[RecommendationCandidate]:
+def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationCandidate]:
     return [RecommendationCandidate(
         item_id=rec["ID"],
         publisher=rec["PUBLISHER"],
-        feed_id=int(feed_id)
+        feed_id=feed_id
     ) for rec in records]
 
 
@@ -53,7 +53,7 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
     set_params = [{"LANG": "EN", "CANDIDATE_SET_ID": CURATED_LONGREADS_CANDIDATE_SET_ID_EN,
                    "FEED_ID": int(NewTabFeedID.en_US)},
                   {"LANG": "DE", "CANDIDATE_SET_ID": CURATED_LONGREADS_CANDIDATE_SET_ID_DE,
-                   "FEED_ID": NewTabFeedID.de_DE}]
+                   "FEED_ID": int(NewTabFeedID.de_DE)}]
 
     # Fetch the most recent curated longreads per langauge
     longreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_LONGREADS_ITEMS_SQL))

--- a/src/flows/recommendation_api/longreads_flow.py
+++ b/src/flows/recommendation_api/longreads_flow.py
@@ -1,0 +1,71 @@
+from typing import List
+from prefect import Flow, task, unmapped
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
+from common_tasks.corpus_candidate_set import (
+    create_corpus_candidate_set_record,
+    load_feature_record,
+    feature_group,
+    validate_candidate_items,
+)
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+FLOW_NAME = get_flow_name(__file__)
+
+CURATED_LONGREADS_CANDIDATE_SET_ID_EN = "8fa462a6-81d1-47ee-8de3-1e5e0030e6d6"
+CURATED_LONGREADS_CANDIDATE_SET_ID_DE = "cff478b9-301e-47cb-accf-ef2fe84ef17a"
+
+# Export approved corpus items by language and recency
+EXPORT_LONGREADS_ITEMS_SQL = """
+SELECT 
+    a.resolved_id as "ID", 
+    c.top_domain_name as "PUBLISHER"
+FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS" AS a
+JOIN "ANALYTICS"."DBT"."CONTENT" AS c
+  ON c.CONTENT_ID = a.CONTENT_ID
+WHERE a.REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD("day", -90, current_timestamp())
+AND c.WORD_COUNT >= 4500
+AND a.CORPUS_REVIEW_STATUS = 'recommendation'
+AND a.LANGUAGE = %(LANG)s
+AND a.IS_SYNDICATED = 0
+ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
+LIMIT 90
+"""
+
+@task()
+def transform_to_candidates(records: dict, feed_id: NewTabFeedID) -> List[RecommendationCandidate]:
+    return [RecommendationCandidate(
+        item_id=rec["ID"],
+        publisher=rec["PUBLISHER"],
+        feed_id=int(feed_id)
+    ) for rec in records]
+
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+
+    query = PocketSnowflakeQuery(
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DICT
+    )
+
+    set_params = [{"LANG": "EN", "CANDIDATE_SET_ID": CURATED_LONGREADS_CANDIDATE_SET_ID_EN,
+                   "FEED_ID": int(NewTabFeedID.en_US)},
+                  {"LANG": "DE", "CANDIDATE_SET_ID": CURATED_LONGREADS_CANDIDATE_SET_ID_DE,
+                   "FEED_ID": NewTabFeedID.de_DE}]
+
+    # Fetch the most recent curated longreads per langauge
+    longreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_LONGREADS_ITEMS_SQL))
+
+    valid_longreads_candidate_items = validate_candidate_items.map(longreads_candidate_items)
+
+    # Write longreads candidate sets to SQS
+    candidate_sets = transform_to_candidates.map(valid_longreads_candidate_items,
+                                                 [p["FEED_ID"] for p in set_params])
+
+    put_results.map([p["CANDIDATE_SET_ID"] for p in set_params],
+                    candidate_sets, curated=unmapped(True))
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/recommendation_api/shortreads_flow.py
+++ b/src/flows/recommendation_api/shortreads_flow.py
@@ -13,7 +13,7 @@ from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)
 
-CURATED_SHORTREADS_CANDIDATE_SET_ID_EN = "626397d3-fa4e-4299-8d07-cbeaa269ebc1"
+CURATED_SHORTREADS_CANDIDATE_SET_ID_EN = "7ef90242-ff7a-44ac-8a32-53193e4a23eb"
 CURATED_SHORTREADS_CANDIDATE_SET_ID_DE = "57e4d3d1-9b4a-4a35-82f4-e577d88f6521"
 
 # Export approved corpus items by language and recency

--- a/src/flows/recommendation_api/shortreads_flow.py
+++ b/src/flows/recommendation_api/shortreads_flow.py
@@ -34,11 +34,11 @@ LIMIT 90
 """
 
 @task()
-def transform_to_candidates(records: dict, feed_id: NewTabFeedID) -> List[RecommendationCandidate]:
+def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationCandidate]:
     return [RecommendationCandidate(
         item_id=rec["ID"],
         publisher=rec["PUBLISHER"],
-        feed_id=int(feed_id)
+        feed_id=feed_id
     ) for rec in records]
 
 
@@ -54,7 +54,7 @@ with Flow(FLOW_NAME) as flow:
     set_params = [{"LANG": "EN", "CANDIDATE_SET_ID": CURATED_SHORTREADS_CANDIDATE_SET_ID_EN,
                    "FEED_ID": int(NewTabFeedID.en_US)},
                   {"LANG": "DE", "CANDIDATE_SET_ID": CURATED_SHORTREADS_CANDIDATE_SET_ID_DE,
-                   "FEED_ID": NewTabFeedID.de_DE}]
+                   "FEED_ID": int(NewTabFeedID.de_DE)}]
 
     # Fetch the most recent curated shortreads per langauge
     shortreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_LONGREADS_ITEMS_SQL))

--- a/src/flows/recommendation_api/shortreads_flow.py
+++ b/src/flows/recommendation_api/shortreads_flow.py
@@ -1,0 +1,73 @@
+from typing import List
+from prefect import Flow, task, unmapped
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
+from common_tasks.corpus_candidate_set import (
+    create_corpus_candidate_set_record,
+    load_feature_record,
+    feature_group,
+    validate_candidate_items,
+)
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+FLOW_NAME = get_flow_name(__file__)
+
+CURATED_SHORTREADS_CANDIDATE_SET_ID_EN = "626397d3-fa4e-4299-8d07-cbeaa269ebc1"
+CURATED_SHORTREADS_CANDIDATE_SET_ID_DE = "57e4d3d1-9b4a-4a35-82f4-e577d88f6521"
+
+# Export approved corpus items by language and recency
+EXPORT_LONGREADS_ITEMS_SQL = """
+SELECT 
+    a.resolved_id as "ID", 
+    c.top_domain_name as "PUBLISHER"
+FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS" AS a
+JOIN "ANALYTICS"."DBT"."CONTENT" AS c
+  ON c.CONTENT_ID = a.CONTENT_ID
+WHERE a.REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD("day", -90, current_timestamp())
+AND c.WORD_COUNT <= 900
+AND a.CORPUS_REVIEW_STATUS = 'recommendation'
+AND a.LANGUAGE = %(LANG)s
+AND a.IS_SYNDICATED = 0
+ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
+LIMIT 90
+"""
+
+@task()
+def transform_to_candidates(records: dict, feed_id: NewTabFeedID) -> List[RecommendationCandidate]:
+    return [RecommendationCandidate(
+        item_id=rec["ID"],
+        publisher=rec["PUBLISHER"],
+        feed_id=int(feed_id)
+    ) for rec in records]
+
+
+# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
+
+    query = PocketSnowflakeQuery(
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DICT
+    )
+
+    set_params = [{"LANG": "EN", "CANDIDATE_SET_ID": CURATED_SHORTREADS_CANDIDATE_SET_ID_EN,
+                   "FEED_ID": int(NewTabFeedID.en_US)},
+                  {"LANG": "DE", "CANDIDATE_SET_ID": CURATED_SHORTREADS_CANDIDATE_SET_ID_DE,
+                   "FEED_ID": NewTabFeedID.de_DE}]
+
+    # Fetch the most recent curated shortreads per langauge
+    shortreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_LONGREADS_ITEMS_SQL))
+
+    valid_shortreads_candidate_items = validate_candidate_items.map(shortreads_candidate_items)
+
+    # Write shortreads candidate sets to SQS
+    candidate_sets = transform_to_candidates.map(valid_shortreads_candidate_items,
+                                                 [p["FEED_ID"] for p in set_params])
+
+    put_results.map([p["CANDIDATE_SET_ID"] for p in set_params],
+                    candidate_sets, curated=unmapped(True))
+
+
+if __name__ == "__main__":
+    flow.run()


### PR DESCRIPTION
## Goal

This adds two flows to prefect for candidate generation for recommendation-api candidate sets (which are actively being impressed).

* Curated Longreads: items from the recommended corpus with at least 3600 words ordered by review time (descending)
* Curate Shortreads:  items from the recommended corpus with at most 900 words ordered by review time (descending)

## Implementation Decisions

* for each, we've created candidate sets for English language and German language recommendations
* we're reusing the existing candidate set GUIDs for the English content
* limited candidate sets to 90 

## References

[google sheet](https://docs.google.com/spreadsheets/d/1uX6PJNegioGfQEyec4ybe4GVcetXs5xhWCigMNgA4_0/edit?usp=sharing) with slates that are getting impressions in August 2022

