### PR TITLE
adding curated and syndciated candidate sets

### DIFF
--- a/src/api_clients/sqs.py
+++ b/src/api_clients/sqs.py
@@ -4,7 +4,7 @@ import uuid
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, List
-from typing import Union
+from typing import Union, Dict
 
 import boto3
 import prefect
@@ -75,6 +75,19 @@ class SQSConfig:
                              sqs_queue=SQS_REC_QUEUE)
     prospecting = SQSInfo(name=CandidateType.prospect,
                           sqs_queue=SQS_PROSPECT_QUEUE)
+
+
+@task()
+def validate_candidate_items(corpus_items: List[Dict]):
+    min_item_count = 1
+    expected_keys = ['ID', 'PUBLISHER']
+
+    assert len(corpus_items) >= min_item_count
+    assert all(set(expected_keys).difference(set(corpus_item.keys())) == set() for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['ID'], int) and corpus_item['ID'] != None for corpus_item in corpus_items)
+    assert all(isinstance(corpus_item['PUBLISHER'], str) and corpus_item['PUBLISHER'] != '' for corpus_item in corpus_items)
+
+    return corpus_items
 
 
 @task()

--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -23,18 +23,6 @@ def validate_corpus_items(corpus_items: List[Dict]):
 
     return corpus_items
 
-@task()
-def validate_candidate_items(corpus_items: List[Dict]):
-    min_item_count = 1
-    expected_keys = ['ID', 'PUBLISHER']
-
-    assert len(corpus_items) >= min_item_count
-    assert all(set(expected_keys).difference(set(corpus_item.keys())) == set() for corpus_item in corpus_items)
-    assert all(isinstance(corpus_item['ID'], int) and corpus_item['ID'] != None for corpus_item in corpus_items)
-    assert all(isinstance(corpus_item['PUBLISHER'], str) and corpus_item['PUBLISHER'] != '' for corpus_item in corpus_items)
-
-    return corpus_items
-
 
 @task()
 def create_corpus_candidate_set_record(

--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -29,7 +29,7 @@ def validate_candidate_items(corpus_items: List[Dict]):
     expected_keys = ['ID', 'PUBLISHER']
 
     assert len(corpus_items) >= min_item_count
-    assert all(list(corpus_item.keys()) == expected_keys for corpus_item in corpus_items)
+    assert all(set(expected_keys).difference(set(corpus_item.keys())) == set() for corpus_item in corpus_items)
     assert all(isinstance(corpus_item['ID'], int) and corpus_item['ID'] != None for corpus_item in corpus_items)
     assert all(isinstance(corpus_item['PUBLISHER'], str) and corpus_item['PUBLISHER'] != '' for corpus_item in corpus_items)
 

--- a/src/flows/recommendation_api/curated_feeds_flow.py
+++ b/src/flows/recommendation_api/curated_feeds_flow.py
@@ -1,0 +1,77 @@
+from typing import List
+from prefect import Flow, task, unmapped
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
+from common_tasks.corpus_candidate_set import validate_candidate_items
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+FLOW_NAME = get_flow_name(__file__)
+
+CURATED_EN_US_CANDIDATE_SET_ID = "35018233-48cd-4ec4-bcfd-7b1b1ccf30de"
+CURATED_DE_DE_CANDIDATE_SET_ID = "c66a1485-6c87-4c68-b29e-e7e838465ff7"
+CURATED_EN_US_NO_SYND_CANDIDATE_SET_ID = "493a5556-9800-449f-8f8c-c27bb6c8c810"
+
+# Export approved corpus items by language and recency
+EXPORT_SCHEDULED_ITEMS_SQL = """
+SELECT 
+    a.resolved_id as "ID", 
+    a.IS_SYNDICATED as "IS_SYNDICATED",
+    c.top_domain_name as "PUBLISHER"
+FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS" AS a
+JOIN "ANALYTICS"."DBT"."CONTENT" AS c
+  ON c.CONTENT_ID = a.CONTENT_ID
+WHERE a.SCHEDULED_CORPUS_ITEM_SCHEDULED_AT BETWEEN DATEADD("day", -7, current_timestamp()) AND current_timestamp()
+AND a.SCHEDULED_SURFACE_ID = %(SCHEDULED_SURFACE)s
+ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT desc
+LIMIT 180
+"""
+
+@task()
+def transform_to_candidates(records: dict, feed_id: int, filter_synd: bool) -> List[RecommendationCandidate]:
+
+    if filter_synd:
+        return [RecommendationCandidate(
+            item_id=rec["ID"],
+            publisher=rec["PUBLISHER"],
+            feed_id=feed_id
+        ) for rec in records if rec["IS_SYNDICATED"] == 0]
+    else:
+        return [RecommendationCandidate(
+            item_id=rec["ID"],
+            publisher=rec["PUBLISHER"],
+            feed_id=feed_id
+        ) for rec in records]
+
+
+with Flow(FLOW_NAME) as flow:
+# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+
+    query = PocketSnowflakeQuery(
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DICT
+    )
+
+    set_params = [{"SCHEDULED_SURFACE": "NEW_TAB_EN_US", "CANDIDATE_SET_ID": CURATED_EN_US_CANDIDATE_SET_ID,
+                   "FEED_ID": int(NewTabFeedID.en_US), "FILTER_SYND": False},
+                  {"SCHEDULED_SURFACE": "NEW_TAB_EN_US", "CANDIDATE_SET_ID": CURATED_EN_US_NO_SYND_CANDIDATE_SET_ID,
+                   "FEED_ID": int(NewTabFeedID.en_US), "FILTER_SYND": True},
+                  {"SCHEDULED_SURFACE": "NEW_TAB_DE_DE", "CANDIDATE_SET_ID": CURATED_DE_DE_CANDIDATE_SET_ID,
+                   "FEED_ID": int(NewTabFeedID.de_DE), "FILTER_SYND": False}]
+
+    # Fetch the most recent curated items per candidate set
+    scheduled_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_SCHEDULED_ITEMS_SQL))
+
+    valid_scheduled_candidate_items = validate_candidate_items.map(scheduled_candidate_items)
+
+    # post curated candidate sets to SQS
+    candidate_sets = transform_to_candidates.map(valid_scheduled_candidate_items,
+                                                 [p["FEED_ID"] for p in set_params],
+                                                 [p["FILTER_SYND"] for p in set_params])
+
+    put_results.map([p["CANDIDATE_SET_ID"] for p in set_params],
+                    candidate_sets, curated=unmapped(True))
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/recommendation_api/curated_feeds_flow.py
+++ b/src/flows/recommendation_api/curated_feeds_flow.py
@@ -2,8 +2,7 @@ from typing import List
 from prefect import Flow, task, unmapped
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
-from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
-from common_tasks.corpus_candidate_set import validate_candidate_items
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID, validate_candidate_items
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)

--- a/src/flows/recommendation_api/curated_feeds_flow.py
+++ b/src/flows/recommendation_api/curated_feeds_flow.py
@@ -44,8 +44,7 @@ def transform_to_candidates(records: dict, feed_id: int, filter_synd: bool) -> L
         ) for rec in records]
 
 
-with Flow(FLOW_NAME) as flow:
-# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -45,8 +45,7 @@ def transform_to_candidates(records: dict) -> List[RecommendationCandidate]:
         feed_id=int(NewTabFeedID.en_US)
     ) for rec in records]
 
-#with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
-with Flow(FLOW_NAME) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -2,9 +2,7 @@ from typing import List
 from prefect import Flow, Parameter, unmapped, task
 from prefect.executors import LocalDaskExecutor
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
-from common_tasks.corpus_candidate_set import (
-    validate_candidate_items,
-)
+from api_clients.sqs import validate_candidate_items
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID

--- a/src/flows/recommendation_api/legacy_topics_flow.py
+++ b/src/flows/recommendation_api/legacy_topics_flow.py
@@ -45,7 +45,8 @@ def transform_to_candidates(records: dict) -> List[RecommendationCandidate]:
         feed_id=int(NewTabFeedID.en_US)
     ) for rec in records]
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+#with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+with Flow(FLOW_NAME) as flow:
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,

--- a/src/flows/recommendation_api/longreads_flow.py
+++ b/src/flows/recommendation_api/longreads_flow.py
@@ -2,13 +2,7 @@ from typing import List
 from prefect import Flow, task, unmapped
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
-from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
-from common_tasks.corpus_candidate_set import (
-    create_corpus_candidate_set_record,
-    load_feature_record,
-    feature_group,
-    validate_candidate_items,
-)
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID, validate_candidate_items
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)

--- a/src/flows/recommendation_api/shortreads_flow.py
+++ b/src/flows/recommendation_api/shortreads_flow.py
@@ -2,13 +2,7 @@ from typing import List
 from prefect import Flow, task, unmapped
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
-from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
-from common_tasks.corpus_candidate_set import (
-    create_corpus_candidate_set_record,
-    load_feature_record,
-    feature_group,
-    validate_candidate_items,
-)
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID, validate_candidate_items
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)
@@ -17,7 +11,7 @@ CURATED_SHORTREADS_CANDIDATE_SET_ID_EN = "7ef90242-ff7a-44ac-8a32-53193e4a23eb"
 CURATED_SHORTREADS_CANDIDATE_SET_ID_DE = "57e4d3d1-9b4a-4a35-82f4-e577d88f6521"
 
 # Export approved corpus items by language and recency
-EXPORT_LONGREADS_ITEMS_SQL = """
+EXPORT_SHORTREADS_ITEMS_SQL = """
 SELECT 
     a.resolved_id as "ID", 
     c.top_domain_name as "PUBLISHER"
@@ -57,7 +51,7 @@ with Flow(FLOW_NAME) as flow:
                    "FEED_ID": int(NewTabFeedID.de_DE)}]
 
     # Fetch the most recent curated shortreads per langauge
-    shortreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_LONGREADS_ITEMS_SQL))
+    shortreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_SHORTREADS_ITEMS_SQL))
 
     valid_shortreads_candidate_items = validate_candidate_items.map(shortreads_candidate_items)
 

--- a/src/flows/recommendation_api/syndicated_feed_flow.py
+++ b/src/flows/recommendation_api/syndicated_feed_flow.py
@@ -2,8 +2,7 @@ from typing import List
 from prefect import Flow, task
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
-from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
-from common_tasks.corpus_candidate_set import validate_candidate_items
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID, validate_candidate_items
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)

--- a/src/flows/recommendation_api/syndicated_feed_flow.py
+++ b/src/flows/recommendation_api/syndicated_feed_flow.py
@@ -33,8 +33,7 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
     ) for rec in records]
 
 
-with Flow(FLOW_NAME) as flow:
-# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
 
     # query snowflake for items from pocket hits
     records = PocketSnowflakeQuery()(

--- a/src/flows/recommendation_api/syndicated_feed_flow.py
+++ b/src/flows/recommendation_api/syndicated_feed_flow.py
@@ -1,0 +1,59 @@
+from typing import List
+from prefect import Flow, task
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID
+from common_tasks.corpus_candidate_set import validate_candidate_items
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+FLOW_NAME = get_flow_name(__file__)
+
+SYNDICATED_EN_US_CANDIDATE_SET_ID = "a8425a46-187a-4cdb-8157-5d2f308c52cd"
+
+# Export approved corpus items by language and recency
+EXPORT_SCHEDULED_ITEMS_SQL = """
+SELECT 
+    s.resolved_id as "ID", 
+    c.DOMAIN as "PUBLISHER"
+FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS" AS s
+JOIN "ANALYTICS"."DBT"."SYNDICATED_ARTICLES" AS c
+  ON c.POCKET_RESOLVED_ID = s.RESOLVED_ID
+WHERE s.SCHEDULED_CORPUS_ITEM_SCHEDULED_AT BETWEEN DATEADD("day", %(MAX_AGE_DAYS)s, current_timestamp()) AND current_timestamp()
+AND s.SCHEDULED_SURFACE_ID = %(SCHEDULED_SURFACE_ID)s
+ORDER BY s.SCHEDULED_CORPUS_ITEM_SCHEDULED_AT desc
+LIMIT 180
+"""
+
+@task()
+def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationCandidate]:
+    return [RecommendationCandidate(
+        item_id=rec["ID"],
+        publisher=rec["PUBLISHER"],
+        feed_id=feed_id
+    ) for rec in records]
+
+
+with Flow(FLOW_NAME) as flow:
+# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+
+    # query snowflake for items from pocket hits
+    records = PocketSnowflakeQuery()(
+        query=EXPORT_SCHEDULED_ITEMS_SQL,
+        data={
+            "MAX_AGE_DAYS": -9,
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_US"
+        },
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+        output_type=OutputType.DICT,
+    )
+
+    valid_scheduled_candidate_items = validate_candidate_items(records)
+
+    # post curated candidate sets to SQS
+    candidate_set = transform_to_candidates(valid_scheduled_candidate_items, int(NewTabFeedID.en_US))
+
+    put_results(SYNDICATED_EN_US_CANDIDATE_SET_ID, candidate_set)
+
+if __name__ == "__main__":
+    flow.run()


### PR DESCRIPTION
## Goal

This PR migrates several recommendation-api candidate set generation flows to prefect.  The goal is to deprecate the CuratedNotNewTabFlow and SyndicatedFlow.  The flows here are intended to cover the following candidate sets:

"35018233-48cd-4ec4-bcfd-7b1b1ccf30de" : live en-US new tab feed ordered by new tab schedule
"c66a1485-6c87-4c68-b29e-e7e838465ff7" : live de-DE new tab feed ordered by curator schedule
"493a5556-9800-449f-8f8c-c27bb6c8c810" : live en-US new tab feed ordered by new tab schedule w/o syndicated items
"a8425a46-187a-4cdb-8157-5d2f308c52cd" : live syndicated ONLY new tab en-US feed

## Implementation Decisions
 
* used the en_US new tab to order syndicated items instead of trying for a "high-performaing syndicated" candidate set under theory that curators are working harder to blend older and newer syndicated content for new tab these days
* included a week's worth of items (no older) this can be changed... but we never do


## References

[google sheet](https://docs.google.com/spreadsheets/d/1uX6PJNegioGfQEyec4ybe4GVcetXs5xhWCigMNgA4_0/edit?usp=sharing) showing slates that get impressions in August 2022
