### PR TITLE
Scheduling fix

### DIFF
--- a/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
@@ -1,10 +1,12 @@
+import datetime
 from typing import List
 from prefect import Flow, task, unmapped
+from prefect.schedules import IntervalSchedule
 
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
 from api_clients.sqs import put_results, RecommendationCandidate, NewTabFeedID, validate_candidate_items
 from utils import config
-from utils.flow import get_flow_name, get_interval_schedule
+from utils.flow import get_flow_name
 FLOW_NAME = get_flow_name(__file__)
 
 CURATED_SHORTREADS_CANDIDATE_SET_ID_EN = "7ef90242-ff7a-44ac-8a32-53193e4a23eb"
@@ -35,9 +37,13 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
         feed_id=feed_id
     ) for rec in records]
 
+# Schedule to run every three hours
+if config.ENVIRONMENT == config.ENV_PROD:
+    schedule = IntervalSchedule(interval=datetime.timedelta(minutes=180))
+else:
+    schedule = None
 
-# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
-with Flow(FLOW_NAME) as flow:
+with Flow(FLOW_NAME, schedule=schedule) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,


### PR DESCRIPTION
## Goal

Small changes to the scheduling interval for the legacy candidate generation flows for the recommendation-api.

## Implementation Decisions
 
By conditioning on the environment variable that is set in config, we allow for running the flows immediately when testing in dev and running on a schedule when in production.

Changed interval for shortreads and longreads flows to 3 hours.
