### PR TITLE
fix(legacy candiate sets): Short and long read schedules

### DIFF
--- a/src/flows/recommendation_api/legacy_candidate_sets/longreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/longreads.py
@@ -36,7 +36,7 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
     ) for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=180)) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,

--- a/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
@@ -36,8 +36,7 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
     ) for rec in records]
 
 
-# with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
-with Flow(FLOW_NAME) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=180)) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,


### PR DESCRIPTION
## Goal
- Enable shortreads schedule that was accidentally disabled.
- Changed interval for shortreads and longreads flows to 3 hours.