### PR TITLE
Fix task definition memory

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -28,7 +28,7 @@ const prefect = {
     // See the documentation below for valid values for CPU and memory:
     // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu
     cpu: 4096,
-    memory: 32768,
+    memory: 30720,
     dataLearningBucketName: isDev
       ? 'pocket-data-learning-dev'
       : 'pocket-data-learning',


### PR DESCRIPTION
## Goal

Fix task definition memory.

## Implementation Decisions

ECS takes 30GB of memory, not 32GB.