### PR TITLE
Hourly flow

### DIFF
--- a/src/flows/dbt_hourly_flow.py
+++ b/src/flows/dbt_hourly_flow.py
@@ -1,13 +1,12 @@
 from prefect import Flow
-from prefect.executors import LocalDaskExecutor
 from prefect.tasks.dbt import dbt
 
-from utils.flow import get_flow_name, get_interval_schedule
+from utils.flow import get_flow_name
 
 FLOW_NAME = get_flow_name(__file__)
 DBT_CLOUD_JOB_ID = 52822
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+with Flow(FLOW_NAME) as flow:
     dbt.DbtCloudRunJob().run(cause=FLOW_NAME, job_id=DBT_CLOUD_JOB_ID, wait_for_job_run_completion=True)
 
 if __name__ == "__main__":

--- a/src/flows/dbt_hourly_flow.py
+++ b/src/flows/dbt_hourly_flow.py
@@ -1,0 +1,14 @@
+from prefect import Flow
+from prefect.executors import LocalDaskExecutor
+from prefect.tasks.dbt import dbt
+
+from utils.flow import get_flow_name, get_interval_schedule
+
+FLOW_NAME = get_flow_name(__file__)
+DBT_CLOUD_JOB_ID = 52822
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+    dbt.DbtCloudRunJob().run(cause=FLOW_NAME, job_id=DBT_CLOUD_JOB_ID, wait_for_job_run_completion=True)
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/hourly_flow.py
+++ b/src/flows/hourly_flow.py
@@ -1,54 +1,44 @@
-from prefect import Flow, task, unmapped
-from prefect.tasks.dbt import dbt
-from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
+from prefect import Flow, unmapped
 from prefect.executors import LocalDaskExecutor
-from utils import config
+from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
 
+from flows import dbt_hourly_flow, parser_item_html_text_streaming_flow
 from flows.braze import update_flow as braze_update_flow
 from flows.prospecting import prereview_engagement_feature_store_flow, postreview_engagement_feature_store_flow
-from flows import dbt_hourly_flow
+from flows.recommendation_api.corpus_candidate_sets import hourly_flow as corpus_candidate_sets_hourly_flow
+from flows.recommendation_api.legacy_candidate_sets import hourly_flow as legacy_candidate_sets_hourly_flow
+from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 
 FLOW_NAME = get_flow_name(__file__)
-DBT_CLOUD_JOB_ID = 52822
 
-# List of flow names that will be run after the Dbt job run has finished successfully.
 EXTRACT_FLOWS = [
-]
-
-PRE_ENRICH_FLOWS = [
+    parser_item_html_text_streaming_flow.FLOW_NAME
 ]
 
 TRANSFORM_FLOWS = [
-    flows.dbt_hourly_flow,
+    dbt_hourly_flow.FLOW_NAME,
 ]
 
 LOAD_FLOWS = [
     braze_update_flow.FLOW_NAME,
     prereview_engagement_feature_store_flow.FLOW_NAME,
     postreview_engagement_feature_store_flow.FLOW_NAME,
+    corpus_candidate_sets_hourly_flow.FLOW_NAME,
+    legacy_candidate_sets_hourly_flow.FLOW_NAME,
 ]
 
-@task(timeout=15 * 60)
-def transform():
-    return dbt.DbtCloudRunJob().run(cause=FLOW_NAME, job_id=DBT_CLOUD_JOB_ID, wait_for_job_run_completion=True)
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60), executor=LocalDaskExecutor()) as flow:
+    project_name = unmapped(config.PREFECT_PROJECT_NAME);
 
+    extract_ids = create_flow_run.map(flow_name=EXTRACT_FLOWS, project_name=project_name)
+    extract_complete = wait_for_flow_run.map(extract_ids)
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
-    dbt_run_result = transform()
+    transform_ids = create_flow_run.map(flow_name=TRANSFORM_FLOWS, project_name=project_name).set_upstream(extract_complete)
+    transform_complete = wait_for_flow_run.map(transform_ids)
 
-    load_results = create_flow_run.map(
-        flow_name=LOAD_FLOWS,
-        project_name=unmapped(config.PREFECT_PROJECT_NAME),
-        upstream_tasks=[dbt_run_result],
-    )
+    load_ids = create_flow_run.map(flow_name=LOAD_FLOWS, project_name=project_name).set_upstream(transform_complete)
+    load_complete = wait_for_flow_run.map(load_ids)
 
-    wait_for_flow_run.map(
-        load_results,
-        raise_final_state=unmapped(True),
-    )
-
-# for execution in development only
 if __name__ == "__main__":
-    # flow.visualize()
     flow.run()

--- a/src/flows/parser_item_html_text_streaming_flow.py
+++ b/src/flows/parser_item_html_text_streaming_flow.py
@@ -143,7 +143,7 @@ def cleanup(key: str):
     s3.Object(bucket, key).delete()
 
 
-with Flow(FLOW_NAME, executor=LocalDaskExecutor(), schedule=get_interval_schedule(minutes=1440)) as flow:
+with Flow(FLOW_NAME, executor=LocalDaskExecutor()) as flow:
     source_keys_results = get_source_keys()
     extract_results = extract.map(source_keys_results)
     transform_results = transform.map(extract_results)

--- a/src/flows/recommendation_api/corpus_candidate_sets/collections_by_recency.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/collections_by_recency.py
@@ -26,7 +26,7 @@ AND LANGUAGE = 'EN'
 ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
 """
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_COLLECTIONS_CANDIDATE_SET_SQL,
         data={"MAX_AGE_DAYS": -60},

--- a/src/flows/recommendation_api/corpus_candidate_sets/hourly_flow.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/hourly_flow.py
@@ -1,0 +1,28 @@
+from prefect import Flow, unmapped
+from prefect.executors import LocalDaskExecutor
+from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
+
+from flows.recommendation_api.corpus_candidate_sets import collections_by_recency, lifehacks, new_tab_not_syndicated, \
+    pockethits, recommended_by_recency, setup_moment_editorial_selection, setup_moment_scheduled_syndicated, topics
+from utils import config
+from utils.flow import get_flow_name
+
+FLOW_NAME = get_flow_name(__file__)
+
+FLOW_NAMES = [
+    collections_by_recency.FLOW_NAME,
+    lifehacks.FLOW_NAME,
+    new_tab_not_syndicated.FLOW_NAME,
+    pockethits.FLOW_NAME,
+    recommended_by_recency.FLOW_NAME,
+    setup_moment_editorial_selection.FLOW_NAME,
+    setup_moment_scheduled_syndicated.FLOW_NAME,
+    topics.FLOW_NAME,
+]
+
+with Flow(FLOW_NAME, executor=LocalDaskExecutor()) as flow:
+    ids = create_flow_run.map(flow_name=FLOW_NAMES, project_name=unmapped(config.PREFECT_PROJECT_NAME))
+    wait_for_flow_run.map(ids)
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/recommendation_api/corpus_candidate_sets/lifehacks.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/lifehacks.py
@@ -35,7 +35,7 @@ def transform_to_corpus_items(records: dict) -> List[dict]:
         for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
 
     # query snowflake for items from lifehacks topic set
     records = PocketSnowflakeQuery()(

--- a/src/flows/recommendation_api/corpus_candidate_sets/new_tab_not_syndicated.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/new_tab_not_syndicated.py
@@ -26,7 +26,7 @@ QUALIFY row_number() OVER (PARTITION BY APPROVED_CORPUS_ITEM_EXTERNAL_ID ORDER B
 ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC
 """
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_NEW_TAB_EN_US_NOT_SYNDICATED_CANDIDATE_SET_SQL,
         data={"MAX_AGE_DAYS": -3, "SURFACE_GUID": "NEW_TAB_EN_US"},

--- a/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
@@ -39,7 +39,7 @@ def transform_to_corpus_items(records: dict) -> List[dict]:
         for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+with Flow(FLOW_NAME) as flow:
 
     # query snowflake for items from pocket hits
     records = PocketSnowflakeQuery()(

--- a/src/flows/recommendation_api/corpus_candidate_sets/recommended_by_recency.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/recommended_by_recency.py
@@ -26,7 +26,7 @@ ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
 LIMIT 2000 -- max feature value size / corpus item size ~= 350KB / 100 bytes ~= 3,500 max corpus items 
 """
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_RECOMMENDED_CANDIDATE_SET_SQL,
         data={"MAX_AGE_DAYS": -14},

--- a/src/flows/recommendation_api/corpus_candidate_sets/setup_moment_editorial_selection.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/setup_moment_editorial_selection.py
@@ -85,7 +85,7 @@ WHERE APPROVED_CORPUS_ITEM_EXTERNAL_ID IN ({",".join(f"'{corpus_id}'" for corpus
 """
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+with Flow(FLOW_NAME) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_CORPUS_ITEMS_SQL,
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,

--- a/src/flows/recommendation_api/corpus_candidate_sets/setup_moment_scheduled_syndicated.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/setup_moment_scheduled_syndicated.py
@@ -28,7 +28,7 @@ ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC
 LIMIT 500;
 """
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+with Flow(FLOW_NAME) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_CORPUS_ITEMS_SQL,
         data={

--- a/src/flows/recommendation_api/corpus_candidate_sets/topics.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/topics.py
@@ -34,7 +34,7 @@ FROM analytics.dbt.static_corpus_candidate_set_topics
 def get_candidate_set_ids(topics):
     return [i['CURATED_CORPUS_CANDIDATE_SET_ID'] for i in topics]
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+with Flow(FLOW_NAME, executor=LocalDaskExecutor()) as flow:
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,

--- a/src/flows/recommendation_api/legacy_candidate_sets/curated_feeds.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/curated_feeds.py
@@ -43,7 +43,7 @@ def transform_to_candidates(records: dict, feed_id: int, filter_synd: bool) -> L
         ) for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,

--- a/src/flows/recommendation_api/legacy_candidate_sets/hourly_flow.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/hourly_flow.py
@@ -1,0 +1,24 @@
+from prefect import Flow, unmapped
+from prefect.executors import LocalDaskExecutor
+from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
+
+from flows.recommendation_api.legacy_candidate_sets import curated_feeds, longreads, shortreads, syndicated_feed, topics
+from utils import config
+from utils.flow import get_flow_name
+
+FLOW_NAME = get_flow_name(__file__)
+
+FLOW_NAMES = [
+    curated_feeds.FLOW_NAME,
+    longreads.FLOW_NAME,
+    shortreads.FLOW_NAME,
+    syndicated_feed.FLOW_NAME,
+    topics.FLOW_NAME
+]
+
+with Flow(FLOW_NAME, executor=LocalDaskExecutor()) as flow:
+    ids = create_flow_run.map(flow_name=FLOW_NAMES, project_name=unmapped(config.PREFECT_PROJECT_NAME))
+    wait_for_flow_run.map(ids)
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/recommendation_api/legacy_candidate_sets/longreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/longreads.py
@@ -36,7 +36,7 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
     ) for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=180)) as flow:
+with Flow(FLOW_NAME) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,

--- a/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
@@ -36,7 +36,7 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
     ) for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=180)) as flow:
+with Flow(FLOW_NAME) as flow:
 
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,

--- a/src/flows/recommendation_api/legacy_candidate_sets/syndicated_feed.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/syndicated_feed.py
@@ -32,7 +32,7 @@ def transform_to_candidates(records: dict, feed_id: int) -> List[RecommendationC
     ) for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+with Flow(FLOW_NAME) as flow:
 
     # query snowflake for items from pocket hits
     records = PocketSnowflakeQuery()(

--- a/src/flows/recommendation_api/legacy_candidate_sets/topics.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/topics.py
@@ -43,7 +43,7 @@ def transform_to_candidates(records: dict) -> List[RecommendationCandidate]:
         feed_id=int(NewTabFeedID.en_US)
     ) for rec in records]
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30), executor=LocalDaskExecutor()) as flow:
+with Flow(FLOW_NAME, executor=LocalDaskExecutor()) as flow:
     query = PocketSnowflakeQuery(
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,


### PR DESCRIPTION
## Goal

Orchestrate all systems with dependencies to ensure that their upstream tasks are completed before executing downstream tasks. This should make sure that data is available more quickly even if it's executed less frequently.

## Implementation Decisions

1. There is probably a better way to make patterns of which flows to include. I started by being very explicit about what should be included and ensuring that we would get compiler errors quickly if there was a dependency misalignment. This will take more effort. As the patterns become more clear lets make more investments.
2. `hourly_flow.py` only triggers other flows and does not know anything about executing tasks directly.
3. I thought that it would make sense to treat folders with many flows as modules where they would have their own `hourly_flow.py` to ensure that this module tracked which flows it should include in the hourly process. This may be a good decision or bad. Im not sure, but its something that worked.
4. The dbt flows and downstream flows moved from 30min to hourly. I don't see anything in the `LOAD_FLOWS` which would have a problem with being triggered hourly instead of twice hourly.

