### PR TITLE
Specify number of workers

### DIFF
--- a/src/flows/parser_item_html_backfill_filesplit_flow.py
+++ b/src/flows/parser_item_html_backfill_filesplit_flow.py
@@ -80,7 +80,7 @@ def split_files_process(key: str):
         stage_chunk(key=key, index=index, df=transform(df))
 
 
-with Flow(FLOW_NAME, executor=LocalDaskExecutor(scheduler="threads")) as flow:
+with Flow(FLOW_NAME, executor=LocalDaskExecutor(scheduler="threads", num_workers=5)) as flow:
     num_files = Parameter('num_files', default=NUM_FILES_PER_RUN)
     source_prefix = Parameter('source_prefix', default=SOURCE_PREFIX)
     keys = get_source_keys(source_prefix, num_files)

--- a/src/flows/parser_item_html_backfill_load_flow.py
+++ b/src/flows/parser_item_html_backfill_load_flow.py
@@ -87,7 +87,7 @@ def load(df: pd.DataFrame, key: str):
     obj.put(Body=csv_buffer.getvalue())
 
 
-with Flow(FLOW_NAME, executor=LocalDaskExecutor(scheduler="threads")) as flow:
+with Flow(FLOW_NAME, executor=LocalDaskExecutor(scheduler="threads", num_workers=5)) as flow:
     source_prefix = Parameter('source_prefix', default=SOURCE_PREFIX)
     num_files = Parameter('num_files', default=NUM_FILES_PER_RUN)
 


### PR DESCRIPTION
## Goal

Processes dask scheduler automatically detects number of cores and spins up that many worker. `thread` does not. :( 