### PR TITLE
Modify Pocket Hits candidates

### DIFF
--- a/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
@@ -21,13 +21,14 @@ POCKETHITS_EN_CANDIDATE_SET_ID = "92411893-ebdb-4a43-ad29-aa79e56e2136"
 
 POCKETHITS_SQL = """
 SELECT
-    APPROVED_CORPUS_ITEM_EXTERNAL_ID as ID,
-    TOPIC
-FROM "SCHEDULED_CORPUS_ITEMS"
+    APPROVED_CORPUS_ITEM_EXTERNAL_ID as "ID",
+    TOPIC as "TOPIC"
+FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
 WHERE SCHEDULED_SURFACE_ID = %(SURFACE_GUID)s
 AND SCHEDULED_CORPUS_ITEM_SCHEDULED_AT BETWEEN DATEADD(day, %(MAX_AGE_DAYS)s, CURRENT_DATE) AND CURRENT_DATE
 QUALIFY row_number() OVER (PARTITION BY APPROVED_CORPUS_ITEM_EXTERNAL_ID ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC) = 1
 ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC
+LIMIT 8  -- Only include past Pocket Hits stories if today's aren't available. There are 8 stories per email.
 """
 
 
@@ -39,13 +40,13 @@ def transform_to_corpus_items(records: dict) -> List[dict]:
         for rec in records]
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=30)) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
 
     # query snowflake for items from pocket hits
     records = PocketSnowflakeQuery()(
         query=POCKETHITS_SQL,
         data={
-            "MAX_AGE_DAYS": -9,
+            "MAX_AGE_DAYS": -3,
             "SURFACE_GUID": "POCKET_HITS_EN_US"
         },
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,


### PR DESCRIPTION
## Goal
Limit Pocket Hits candidate set to today's Pocket Hits email if available. Only backfill with older content if not enough content is scheduled for today.

## Implementation decision
- Assume email contains 8 stories. I think the emails currently always contain 8 stories, and I couldn't immediately think of a query to dynamically pull all stories from today, or backfill them with older stories until we have at least 8 of them.

## References

https://getpocket.atlassian.net/browse/HS-163