### PR TITLE
feat(Collection candidates): Go back 120 days

### DIFF
--- a/src/flows/recommendation_api/corpus_candidate_sets/collections_by_recency.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/collections_by_recency.py
@@ -45,7 +45,7 @@ ORDER BY recency DESC
 with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
     corpus_items = PocketSnowflakeQuery()(
         query=EXPORT_COLLECTIONS_CANDIDATE_SET_SQL,
-        data={"MAX_AGE_DAYS": -60},
+        data={"MAX_AGE_DAYS": -120},
         database=config.SNOWFLAKE_ANALYTICS_DATABASE,
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
         output_type=OutputType.DICT,


### PR DESCRIPTION
## Goal
Get collection candidates going back 120 days.

Carolyn:
> My feeling is that given the small size of the Collections corpus, we should ideally change the candidate set. Perhaps we could extend that to 120 days? So many of our collections are evergreen

## References

* [Slack thread](https://pocket.slack.com/archives/C03JSA26QGP/p1667234655287109?thread_ts=1667233294.252559&cid=C03JSA26QGP)

Documentation:
* [Baseline Home Slates spec](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2819228076/Baseline+Home+Slates+spec)
