### PR TITLE
fix(Pocket Hits candidates): Override scheduled time to be 10am EDT [HS-358]

### DIFF
--- a/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
@@ -27,6 +27,7 @@ SELECT
 FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
 WHERE SCHEDULED_SURFACE_ID = %(SURFACE_GUID)s
 -- Pocket Hits content should be available on Home at 3am EST = 7am UTC. Override the scheduled time to 7am.
+-- `DATE_TRUNC` truncates the time, and `DATEADD` adds 7 hours to set the time to 7am UTC. This corresponds to 3am EST.
 -- BACK-1668: `scheduled_at` is always 12am UTC, which is unexpected because Pocket Hits goes out at 10am EST.
 AND DATEADD('hour', 7, DATE_TRUNC('DAY', SCHEDULED_CORPUS_ITEM_SCHEDULED_AT)) < CURRENT_TIMESTAMP
 QUALIFY row_number() OVER (PARTITION BY APPROVED_CORPUS_ITEM_EXTERNAL_ID ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC) = 1

--- a/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
@@ -26,9 +26,9 @@ SELECT
     PUBLISHER as "PUBLISHER"
 FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
 WHERE SCHEDULED_SURFACE_ID = %(SURFACE_GUID)s
+-- Pocket Hits content should be available on Home at 3am EST = 7am UTC. Override the scheduled time to 7am.
 -- BACK-1668: `scheduled_at` is always 12am UTC, which is unexpected because Pocket Hits goes out at 10am EST.
---            The workaround below overrides the time to be 2pm UTC = 10am EST. Can be removed when BACK-1668 is fixed.
-AND DATEADD('hour', 14, DATE_TRUNC('DAY', SCHEDULED_CORPUS_ITEM_SCHEDULED_AT)) < CURRENT_TIMESTAMP
+AND DATEADD('hour', 7, DATE_TRUNC('DAY', SCHEDULED_CORPUS_ITEM_SCHEDULED_AT)) < CURRENT_TIMESTAMP
 QUALIFY row_number() OVER (PARTITION BY APPROVED_CORPUS_ITEM_EXTERNAL_ID ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC) = 1
 ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC
 LIMIT 8  -- Only include past Pocket Hits stories if today's aren't available. There are 8 stories per email.

--- a/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/pockethits.py
@@ -28,7 +28,6 @@ FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
 WHERE SCHEDULED_SURFACE_ID = %(SURFACE_GUID)s
 -- Pocket Hits content should be available on Home at 3am EST = 7am UTC. Override the scheduled time to 7am.
 -- `DATE_TRUNC` truncates the time, and `DATEADD` adds 7 hours to set the time to 7am UTC. This corresponds to 3am EST.
--- BACK-1668: `scheduled_at` is always 12am UTC, which is unexpected because Pocket Hits goes out at 10am EST.
 AND DATEADD('hour', 7, DATE_TRUNC('DAY', SCHEDULED_CORPUS_ITEM_SCHEDULED_AT)) < CURRENT_TIMESTAMP
 QUALIFY row_number() OVER (PARTITION BY APPROVED_CORPUS_ITEM_EXTERNAL_ID ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC) = 1
 ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT DESC


### PR DESCRIPTION
## Goal
Start showing today's Pocket Hits content at 3am EST instead of 12am UTC.

Additional change: Remove condition that content can be at most 3 days old. This had no effect because of the sort order and `LIMIT 8` of most recent stories.

## Implementation Decisions
- For SQL efficiency it would be better not to manipulate a timestamp before doing a comparison, but I couldn't think of a way to meet the requirement without doing this.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/HS-358

Documentation:
* [Content v1 slates spec](https://getpocket.atlassian.net/wiki/spaces/CP/pages/2820046849/Unified+Home+V.1+Enhanced+Experimentation+Slates)
