### PR TITLE
data validation on user_impressions

### DIFF
--- a/src/flows/recommendation_api/user_impressions_flow.py
+++ b/src/flows/recommendation_api/user_impressions_flow.py
@@ -27,9 +27,9 @@ WITH prep AS (
 )
 
 SELECT 
-    HASHED_USER_ID,
-    current_date as UPDATED_AT,
-    ('[' || LISTAGG(DISTINCT CORPUS_ITEM_ID, ',') || ']') AS CORPUS_IDS
+    "HASHED_USER_ID",
+    current_date as "UPDATED_AT",
+    ('[' || LISTAGG(DISTINCT CORPUS_ITEM_ID, ',') || ']') AS "CORPUS_IDS"
 FROM 
     (SELECT * FROM prep WHERE impression_count > %(MAX_IMPRS)s
      UNION 
@@ -40,8 +40,8 @@ GROUP BY 1,2
 
 @task
 def transform_user_impressions_df(df: pd.DataFrame) -> pd.DataFrame:
-    df["UPDATED_AT"] = df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
     df = df.dropna(subset=["HASHED_USER_ID"])
+    df["UPDATED_AT"] = df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
     return df
 
 

--- a/src/flows/recommendation_api/user_impressions_flow.py
+++ b/src/flows/recommendation_api/user_impressions_flow.py
@@ -22,6 +22,7 @@ WITH prep AS (
   FROM "ANALYTICS"."DBT"."IMPRESSIONS" i
   JOIN "ANALYTICS"."DBT_STAGING"."STG_CORPUS_SLATE_RECOMMENDATIONS" r on i.CORPUS_RECOMMENDATION_ID = r.CORPUS_RECOMMENDATION_ID
   WHERE i.HAPPENED_AT > CURRENT_DATE - %(AGG_WINDOW_DAYS)s
+    AND r.HASHED_USER_ID IS NOT NULL
   GROUP BY 1,2
   ORDER BY impression_count DESC
 )
@@ -40,7 +41,6 @@ GROUP BY 1,2
 
 @task
 def transform_user_impressions_df(df: pd.DataFrame) -> pd.DataFrame:
-    df = df.dropna(subset=["HASHED_USER_ID"])
     df["UPDATED_AT"] = df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
     return df
 

--- a/src/flows/recommendation_api/user_impressions_flow.py
+++ b/src/flows/recommendation_api/user_impressions_flow.py
@@ -41,6 +41,7 @@ GROUP BY 1,2
 @task
 def transform_user_impressions_df(df: pd.DataFrame) -> pd.DataFrame:
     df["UPDATED_AT"] = df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    df = df.dropna(subset=["HASHED_USER_ID"])
     return df
 
 


### PR DESCRIPTION
## Goal

user_impressions flow was [failing](https://pocket.slack.com/archives/C02KH5U7G79/p1667779458650989) on a data validation step that reported that `HASHED_USER_ID` was missing.

## Implementation Decisions

Added a line to drop rows that are missing this field.  I find it hard to figure out how many rows are being loaded into the feature group or log it to the console.

