### PR TITLE
feat(Corpus engagement): Load opens/impressions into Feature Group [TDP-181]

### DIFF
--- a/src/common_tasks/load_data.py
+++ b/src/common_tasks/load_data.py
@@ -14,7 +14,7 @@ def dataframe_to_feature_group(dataframe: pd.DataFrame, feature_group_name: str)
     Update SageMaker feature group.
 
     Args:
-        df : the data in a dataframe to upload to the feature group
+        dataframe : the data in a dataframe to upload to the feature group
         feature_group_name: the name of the feature group to upload the data to
 
     Returns:

--- a/src/flows/recommendation_api/corpus_item_engagement.py
+++ b/src/flows/recommendation_api/corpus_item_engagement.py
@@ -1,0 +1,63 @@
+from prefect import task, Flow, Parameter
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery
+import pandas as pd
+import datetime
+
+from common_tasks.load_data import dataframe_to_feature_group
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+
+FLOW_NAME = get_flow_name(__file__)
+
+BASE_QUERY = """
+with trailing_engagement as (
+    SELECT
+        'HOME' as RECOMMENDATION_SURFACE_ID,
+        e.CORPUS_SLATE_CONFIGURATION_ID,
+        e.CORPUS_ITEM_ID,
+
+        -- aggregate impressions
+        sum(case when happened_at >= CURRENT_DATE      then impression_count else 0 end) as trailing_1_day_impressions,
+        sum(case when happened_at >= CURRENT_DATE - 6  then impression_count else 0 end) as trailing_7_day_impressions,
+        sum(case when happened_at >= CURRENT_DATE - 13 then impression_count else 0 end) as trailing_14_day_impressions,
+        sum(case when happened_at >= CURRENT_DATE - 20 then impression_count else 0 end) as trailing_21_day_impressions,
+        sum(case when happened_at >= CURRENT_DATE - 27 then impression_count else 0 end) as trailing_28_day_impressions,
+
+        -- aggregate opens
+        sum(case when happened_at >= CURRENT_DATE      then open_count else 0 end) as trailing_1_day_opens,
+        sum(case when happened_at >= CURRENT_DATE - 6  then open_count else 0 end) as trailing_7_day_opens,
+        sum(case when happened_at >= CURRENT_DATE - 13 then open_count else 0 end) as trailing_14_day_opens,
+        sum(case when happened_at >= CURRENT_DATE - 20 then open_count else 0 end) as trailing_21_day_opens,
+        sum(case when happened_at >= CURRENT_DATE - 27 then open_count else 0 end) as trailing_28_day_opens
+
+    FROM "ANALYTICS"."DBT_MMIERMANS"."CORPUS_RECOMMENDATION_ENGAGEMENT_BY_ITEM_BY_DAY" e
+    WHERE e.happened_at >= CURRENT_DATE - 27
+    GROUP BY 1, 2, 3
+)
+
+SELECT 
+    
+    trailing_engagement.*
+FROM trailing_engagement;
+"""
+
+
+@task
+def transform_df(df: pd.DataFrame) -> pd.DataFrame:
+    key_columns = ['RECOMMENDATION_SURFACE_ID', 'CORPUS_SLATE_CONFIGURATION_ID', 'CORPUS_ITEM_ID']
+    df['KEY'] = df[key_columns].agg('/'.join, axis=1)
+    df['UPDATED_AT'] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return df
+
+
+# Ideally, this flow would be triggered after Dbt model used in the above query is updated.
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
+    feature_group = Parameter("feature group", default=f"{config.ENVIRONMENT}-corpus-engagement-v1")
+
+    snowflake_result = PocketSnowflakeQuery()(query=BASE_QUERY)
+
+    transformed_df = transform_df(snowflake_result)
+    dataframe_to_feature_group(df=transformed_df, feature_group_name=feature_group)
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/recommendation_api/corpus_item_engagement.py
+++ b/src/flows/recommendation_api/corpus_item_engagement.py
@@ -1,7 +1,5 @@
-from prefect import task, Flow, Parameter
+from prefect import Flow
 from api_clients.pocket_snowflake_query import PocketSnowflakeQuery
-import pandas as pd
-import datetime
 
 from common_tasks.load_data import dataframe_to_feature_group
 from utils import config
@@ -11,45 +9,30 @@ FLOW_NAME = get_flow_name(__file__)
 
 BASE_QUERY = """
 SELECT
-    'HOME' as RECOMMENDATION_SURFACE_ID,  -- TDP-192: Get surface id from Snowflake to support surfaces other than Home.
+    SURFACE_CONFIGURATION_ITEM_KEY as KEY,
+    TO_CHAR(updated_at_day, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as UPDATED_AT,  -- Feature Store requires ISO 8601 time format
+    RECOMMENDATION_SURFACE_ID,
     CORPUS_SLATE_CONFIGURATION_ID,
     CORPUS_ITEM_ID,
-
-    -- aggregate impressions
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE      then impression_count else 0 end) as TRAILING_1_DAY_IMPRESSIONS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 6  then impression_count else 0 end) as TRAILING_7_DAY_IMPRESSIONS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 13 then impression_count else 0 end) as TRAILING_14_DAY_IMPRESSIONS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 20 then impression_count else 0 end) as TRAILING_21_DAY_IMPRESSIONS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 27 then impression_count else 0 end) as TRAILING_28_DAY_IMPRESSIONS,
-
-    -- aggregate opens
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE      then open_count else 0 end) as TRAILING_1_DAY_OPENS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 6  then open_count else 0 end) as TRAILING_7_DAY_OPENS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 13 then open_count else 0 end) as TRAILING_14_DAY_OPENS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 20 then open_count else 0 end) as TRAILING_21_DAY_OPENS,
-    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 27 then open_count else 0 end) as TRAILING_28_DAY_OPENS
-
-FROM "ANALYTICS"."DBT"."CORPUS_RECOMMENDATION_ENGAGEMENT_BY_ITEM_BY_DAY"
-WHERE HAPPENED_AT_DAY >= CURRENT_DATE - 27
-GROUP BY 1, 2, 3
+    TRAILING_1_DAY_IMPRESSIONS,
+    TRAILING_1_DAY_OPENS,
+    TRAILING_7_DAY_IMPRESSIONS,
+    TRAILING_7_DAY_OPENS,
+    TRAILING_14_DAY_IMPRESSIONS,
+    TRAILING_14_DAY_OPENS,
+    TRAILING_21_DAY_IMPRESSIONS,
+    TRAILING_21_DAY_OPENS,
+    TRAILING_28_DAY_IMPRESSIONS,
+    TRAILING_28_DAY_OPENS
+FROM ANALYTICS.DBT.CORPUS_RECOMMENDATION_ENGAGEMENT_TRAILING_DAYS_BY_ITEM
 """
-
-
-@task
-def transform_df(df: pd.DataFrame) -> pd.DataFrame:
-    key_columns = ['RECOMMENDATION_SURFACE_ID', 'CORPUS_SLATE_CONFIGURATION_ID', 'CORPUS_ITEM_ID']
-    df['KEY'] = df[key_columns].agg('/'.join, axis=1)
-    df['UPDATED_AT'] = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
-    return df
 
 
 # TODO: Ideally, this flow would be triggered after Dbt model used in the above query is updated, instead of every hour.
 with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
-    snowflake_result = PocketSnowflakeQuery()(query=BASE_QUERY)
-
-    transformed_df = transform_df(snowflake_result)
-
-    dataframe_to_feature_group(transformed_df, feature_group_name=f"{config.ENVIRONMENT}-corpus-engagement-v1")
+    dataframe_to_feature_group(
+        dataframe=PocketSnowflakeQuery()(query=BASE_QUERY),
+        feature_group_name=f"{config.ENVIRONMENT}-corpus-engagement-v1")
 
 if __name__ == "__main__":
     flow.run()

--- a/src/flows/recommendation_api/corpus_item_engagement.py
+++ b/src/flows/recommendation_api/corpus_item_engagement.py
@@ -10,35 +10,28 @@ from utils.flow import get_flow_name, get_interval_schedule
 FLOW_NAME = get_flow_name(__file__)
 
 BASE_QUERY = """
-with trailing_engagement as (
-    SELECT
-        'HOME' as RECOMMENDATION_SURFACE_ID,
-        e.CORPUS_SLATE_CONFIGURATION_ID,
-        e.CORPUS_ITEM_ID,
+SELECT
+    'HOME' as RECOMMENDATION_SURFACE_ID,  -- TDP-192: Get surface id from Snowflake to support surfaces other than Home.
+    CORPUS_SLATE_CONFIGURATION_ID,
+    CORPUS_ITEM_ID,
 
-        -- aggregate impressions
-        sum(case when happened_at >= CURRENT_DATE      then impression_count else 0 end) as trailing_1_day_impressions,
-        sum(case when happened_at >= CURRENT_DATE - 6  then impression_count else 0 end) as trailing_7_day_impressions,
-        sum(case when happened_at >= CURRENT_DATE - 13 then impression_count else 0 end) as trailing_14_day_impressions,
-        sum(case when happened_at >= CURRENT_DATE - 20 then impression_count else 0 end) as trailing_21_day_impressions,
-        sum(case when happened_at >= CURRENT_DATE - 27 then impression_count else 0 end) as trailing_28_day_impressions,
+    -- aggregate impressions
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE      then impression_count else 0 end) as TRAILING_1_DAY_IMPRESSIONS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 6  then impression_count else 0 end) as TRAILING_7_DAY_IMPRESSIONS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 13 then impression_count else 0 end) as TRAILING_14_DAY_IMPRESSIONS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 20 then impression_count else 0 end) as TRAILING_21_DAY_IMPRESSIONS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 27 then impression_count else 0 end) as TRAILING_28_DAY_IMPRESSIONS,
 
-        -- aggregate opens
-        sum(case when happened_at >= CURRENT_DATE      then open_count else 0 end) as trailing_1_day_opens,
-        sum(case when happened_at >= CURRENT_DATE - 6  then open_count else 0 end) as trailing_7_day_opens,
-        sum(case when happened_at >= CURRENT_DATE - 13 then open_count else 0 end) as trailing_14_day_opens,
-        sum(case when happened_at >= CURRENT_DATE - 20 then open_count else 0 end) as trailing_21_day_opens,
-        sum(case when happened_at >= CURRENT_DATE - 27 then open_count else 0 end) as trailing_28_day_opens
+    -- aggregate opens
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE      then open_count else 0 end) as TRAILING_1_DAY_OPENS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 6  then open_count else 0 end) as TRAILING_7_DAY_OPENS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 13 then open_count else 0 end) as TRAILING_14_DAY_OPENS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 20 then open_count else 0 end) as TRAILING_21_DAY_OPENS,
+    sum(case when HAPPENED_AT_DAY >= CURRENT_DATE - 27 then open_count else 0 end) as TRAILING_28_DAY_OPENS
 
-    FROM "ANALYTICS"."DBT_MMIERMANS"."CORPUS_RECOMMENDATION_ENGAGEMENT_BY_ITEM_BY_DAY" e
-    WHERE e.happened_at >= CURRENT_DATE - 27
-    GROUP BY 1, 2, 3
-)
-
-SELECT 
-    
-    trailing_engagement.*
-FROM trailing_engagement;
+FROM "ANALYTICS"."DBT"."CORPUS_RECOMMENDATION_ENGAGEMENT_BY_ITEM_BY_DAY"
+WHERE HAPPENED_AT_DAY >= CURRENT_DATE - 27
+GROUP BY 1, 2, 3
 """
 
 
@@ -50,14 +43,13 @@ def transform_df(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-# Ideally, this flow would be triggered after Dbt model used in the above query is updated.
+# TODO: Ideally, this flow would be triggered after Dbt model used in the above query is updated, instead of every hour.
 with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
-    feature_group = Parameter("feature group", default=f"{config.ENVIRONMENT}-corpus-engagement-v1")
-
     snowflake_result = PocketSnowflakeQuery()(query=BASE_QUERY)
 
     transformed_df = transform_df(snowflake_result)
-    dataframe_to_feature_group(df=transformed_df, feature_group_name=feature_group)
+
+    dataframe_to_feature_group(transformed_df, feature_group_name=f"{config.ENVIRONMENT}-corpus-engagement-v1")
 
 if __name__ == "__main__":
     flow.run()


### PR DESCRIPTION
## Goal
Load open and impression engagement stats into the Feature Group, to support [Thompson sampling](https://en.wikipedia.org/wiki/Thompson_sampling) for Home in Recommendation API.

- Engagement should by grouped by `RECOMMENDATION_SURFACE_ID`, `CORPUS_SLATE_CONFIGURATION_ID`, and `CORPUS_ITEM_ID`, such that we can get engagement metrics for the specific surface (Home) and slate (e.g. 'For You') that recommendations were shown in.
- Engagement should be available on time-scales 1, 7, 14, 21, 28 days. We’re not sure which one we’ll want to use yet, and this gives us flexibility.

## Implementation Decisions
- Key on `RECOMMENDATION_SURFACE_ID/CORPUS_SLATE_CONFIGURATION_ID/CORPUS_ITEM_ID`, to allow Thompson sampling to get Corpus Item engagement for a specific surface and slate. Also include these values separately as features to make it easy to query on them.
- Hardcode `'HOME'` as the recommendation surface id, and come back in [TDP-192](https://getpocket.atlassian.net/browse/TDP-192) to dynamically get this value from Snowflake. By dynamically getting this value we can apply Thompson sampling to surfaces other than Home, but that is out-of-scope for this epic.
- Trigger the flow every hour, because I don't (can't?) know when the Dbt model is updated.
- It is not necessary to remove stale data under the assumption that items are rarely made eligible multiple times on the same slates. In the edge-case where this does happen, Thompson sampling will use stale/historic data only for the first day, after which the feature group will be updated based on new impression and open events.

## Deployment
- [x] Create `development-corpus-engagement-v1` feature group
- [x] Create `production-corpus-engagement-v1` feature group
- [x] Merge https://github.com/Pocket/dbt-snowflake/pull/317

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/TDP-181