### PR TITLE
fix(article_text_weekly_dedup.sql): removing the ownership change and ml_service_role grant

### DIFF
--- a/src/flows/sql/article_text_weekly_dedup.sql
+++ b/src/flows/sql/article_text_weekly_dedup.sql
@@ -1,11 +1,9 @@
 /*
 This will run after an hourly update only once on the weekend
-Will probably need to apply grants to the renamed live table
-Revoke grants will remove access to the old live table for better UX
  */
 
- use warehouse dpt_wh_3xl;
-    
+use warehouse dpt_wh_3xl;
+
 create or replace table article_content_ordered_new as (
 select RESOLVED_ID, 
 HTML, 
@@ -17,13 +15,9 @@ from article_content_ordered_live
 qualify row_number() over (partition by resolved_id order by snowflake_loaded_at desc) = 1
 order by resolved_id);
 
--- clean up ownership
-grant ownership on table article_content_ordered_new to role LOADER REVOKE CURRENT GRANTS;
-
 -- apply proper grants to new ordered table before swap
 
 grant select, delete on table article_content_ordered_new to role USER_DATA_DELETION_ROLE;
-grant all on table article_content_ordered_new to role ML_SERVICE_ROLE;
 grant select on table article_content_ordered_new to role TRANSFORMER;
 grant select on table article_content_ordered_new to role SELECT_ALL_ROLE;
 

--- a/src/flows/sql/initial_clean_article_text_live.sql
+++ b/src/flows/sql/initial_clean_article_text_live.sql
@@ -1,4 +1,7 @@
--- to be run on 3XL Warehouse as a one-time run as role "loader"
+-- to be run on 3XL Warehouse as a one-time run as role "ml_service_role"
+    use role ml_service_role;
+    use warehouse dpt_wh_3xl;
+    
     create or replace table raw.item.article_content_ordered_live as (
     select RESOLVED_ID, 
     HTML, 
@@ -11,8 +14,6 @@
     order by resolved_id);
 
 -- grants needed on new table
-    grant ownership on table raw.item.article_content_ordered_live to role LOADER REVOKE CURRENT GRANTS;
     grant select, delete on table raw.item.article_content_ordered_live to role USER_DATA_DELETION_ROLE;
-    grant all on table raw.item.article_content_ordered_live to role ML_SERVICE_ROLE;
     grant select on table raw.item.article_content_ordered_live to role TRANSFORMER;
     grant select on table raw.item.article_content_ordered_live to role SELECT_ALL_ROLE;

--- a/src/flows/sql/initial_clean_article_text_snapshot.sql
+++ b/src/flows/sql/initial_clean_article_text_snapshot.sql
@@ -1,4 +1,6 @@
 -- to be run on 3XL Warehouse as a one-time run as role "loader"
+    use warehouse dpt_wh_3xl;
+    
     create or replace table snapshot.item.article_content_ordered_snapshot as (
     select RESOLVED_ID, 
     HTML, 


### PR DESCRIPTION

## Goal
What changed? What is the business/product goal?

see bug details at https://getpocket.atlassian.net/browse/TDP-266

removing the ownership change fixes the bug because now ml_service_role is the owner and can apply grants and rename/drop table as needed.

loader does not need to be the owner because the table create statement was not triggered by data-warehouse repo.

also no longer need the older grant to ml_service_role since that role is now the owner of the live table.

ownership change of live table to ml_service_role was done manually

## Implementation Decisions
 
make ml_service_role the owner of the live table
this has no impact on query access to table from downstream workflows/uses

## Deployment steps
- [N/A] Database migrations?
- [N/A] Secrets?
- [ N/A] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):
> Write a #changelog message using our [best practices](https://docs.google.com/document/d/1oEt8Mtkp-6Xz9S2zaNX1EIXfQIEDN2JpY0diuPc1HZc/edit) if this PR (potentially) impacts users. Describe the 'why' and 'what'. @mention relevant teams. Link to this PR.

## References

JIRA ticket:
* [Link to JIRA ticket](https://getpocket.atlassian.net/browse/TDP-266)

Full Script was run as ML_SERVICE_ROLE to validate
