### PR TITLE
Flow to populate a feature group for publisher data

### DIFF
--- a/src/flows/prospecting/publisher_features.py
+++ b/src/flows/prospecting/publisher_features.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 from pathlib import Path
+from typing import Dict
 
 import prefect
 from prefect import Flow, task
@@ -11,12 +12,39 @@ from common_tasks.load_data import dataframe_to_feature_group
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 
-ONE_DAYS_MINS = 24*60  # using this to schedule flow update interval
+ONE_DAY_MINS = 24*60  # using this to schedule flow update interval
+DEFAULT_MIN_WORD_COUNT = 900  # minimum word count for items contributing to publisher features
+DEFAULT_MAX_APPROVED_AGE = 360  # maximum age in days for curation stats for publishers
 VERSION = 1
 
 FEATURE_GROUP_NAME = f"{config.ENVIRONMENT}-PublisherFeatureGroup-v{VERSION}"
 
 FLOW_NAME = get_flow_name(__file__)
+
+@task()
+def get_snowflake_data(query_parameters: Dict) -> pd.DataFrame:
+    logger = prefect.context.get("logger")
+    logger.info(f"Querying snowflake for publisher data")
+
+    # supply required query parameters if missing
+    if "MAX_APPROVED_AGE" not in query_parameters:
+        query_parameters["MAX_APPROVED_AGE"] = DEFAULT_MAX_APPROVED_AGE
+    if "MIN_WORD_COUNT" not in query_parameters:
+        query_parameters["MIN_WORD_COUNT"] = DEFAULT_MIN_WORD_COUNT
+
+    # Read a query from the sql/ directory located next to this flow file.
+    sql_path = os.path.join(os.path.dirname(__file__), "sql/publisher_features.sql")
+    sql_query = Path(sql_path).read_text()
+    # retrieve data from snowflake
+    snowflake_result = PocketSnowflakeQuery().run(
+        query=sql_query,
+        data=query_parameters,
+        output_type=OutputType.DATA_FRAME,
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+    )
+    logger.info(f"snowflake query returned {len(snowflake_result)} rows")
+    return snowflake_result
 
 @task()
 def transform_publisher_features(input_df: pd.DataFrame) -> pd.DataFrame:
@@ -30,7 +58,7 @@ def transform_publisher_features(input_df: pd.DataFrame) -> pd.DataFrame:
     input_df = input_df.dropna(subset=["TOP_DOMAIN_NAME"])
     # reformat update column
     input_df["UPDATED_AT"] = input_df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
-    # remove extra column from query
+    # remove extra column from query which breaks feature group ingestion
     input_df = input_df.drop(columns="APPROVED_SOURCE")
 
     # deal with rows for sources without approved items
@@ -41,37 +69,21 @@ def transform_publisher_features(input_df: pd.DataFrame) -> pd.DataFrame:
     return input_df
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=ONE_DAYS_MINS), executor=LocalDaskExecutor()) as flow:
-
-    logger = prefect.context.get("logger")
-    logger.info(f'Querying snowflake for publisher data')
-
-    # Read a query from the sql/ directory located next to this flow file.
-    sql_path = os.path.join(os.path.dirname(__file__), "sql/publisher_features.sql")
-    sql_query = Path(sql_path).read_text()
+with Flow( FLOW_NAME, schedule=get_interval_schedule(minutes=ONE_DAY_MINS), executor=LocalDaskExecutor()) as flow:
 
     # create query parameters
     query_params = {"MAX_APPROVED_AGE": 360,
                     "MIN_WORD_COUNT": 900}
 
-    # retrieve data from snowflake
-    snowflake_result = PocketSnowflakeQuery().run(
-        query=sql_query,
-        data=query_params,
-        output_type=OutputType.DATA_FRAME,
-        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
-        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
-    )
-    print(f"snowflake query returned {len(snowflake_result)} rows")
-
+    # query data from snowflake
+    sf_data_results = get_snowflake_data(query_params)
     # transform data
-    publisher_df = transform_publisher_features.run(snowflake_result)
-
+    publisher_df = transform_publisher_features(sf_data_results)
     # load data
     result = dataframe_to_feature_group(
-        dataframe=publisher_df,
-        feature_group_name=FEATURE_GROUP_NAME
+        dataframe=publisher_df, feature_group_name=FEATURE_GROUP_NAME
     )
+
 
 if __name__ == "__main__":
     flow.run()

--- a/src/flows/prospecting/publisher_features.py
+++ b/src/flows/prospecting/publisher_features.py
@@ -1,0 +1,77 @@
+import os
+import pandas as pd
+from pathlib import Path
+
+import prefect
+from prefect import Flow, task
+from prefect.executors import LocalDaskExecutor
+
+from api_clients.pocket_snowflake_query import PocketSnowflakeQuery, OutputType
+from common_tasks.load_data import dataframe_to_feature_group
+from utils import config
+from utils.flow import get_flow_name, get_interval_schedule
+
+THREE_DAYS_MINS = 3*24*60  # using this to schedule flow update interval for three days
+VERSION = 1
+
+FEATURE_GROUP_NAME = f"{config.ENVIRONMENT}-PublisherFeatureGroup-v{VERSION}"
+
+FLOW_NAME = get_flow_name(__file__)
+
+@task()
+def transform_publisher_features(input_df: pd.DataFrame) -> pd.DataFrame:
+
+    required_columns = {"TOP_DOMAIN_NAME", "LOG_TOTAL_SAVES", "TOTAL_SAVE_COUNT", "UPDATED_AT"}
+    if len(required_columns.difference(set(input_df.columns))) > 0:
+        missing = required_columns.difference(set(input_df.columns))
+        raise KeyError(f"input dataframe is missing columns: {missing}")
+
+    # TOP_DOMAIN_NAME is required key for feature group
+    input_df = input_df.dropna(subset=["TOP_DOMAIN_NAME"])
+    # reformat update column
+    input_df["UPDATED_AT"] = input_df.UPDATED_AT.apply(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    # remove extra column from query
+    input_df = input_df.drop(columns="APPROVED_SOURCE")
+
+    # deal with rows without approved items
+    approved_cols = [c for c in input_df.columns if c.startswith("NUM_APPROVED")]
+    for c in approved_cols:
+        input_df[c] = input_df[c].fillna(0).astype(int)
+
+    return input_df
+
+
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=THREE_DAYS_MINS), executor=LocalDaskExecutor()) as flow:
+
+    logger = prefect.context.get("logger")
+    logger.info(f'Querying snowflake for publisher data')
+
+    # Read a query from the sql/ directory located next to this flow file.
+    sql_path = os.path.join(os.path.dirname(__file__), "sql/publisher_features.sql")
+    sql_query = Path(sql_path).read_text()
+
+    # create query parameters
+    query_params = {"MAX_APPROVED_AGE": 360,
+                    "MIN_WORD_COUNT": 900}
+
+    # retrieve data from snowflake
+    snowflake_result = PocketSnowflakeQuery().run(
+        query=sql_query,
+        data=query_params,
+        output_type=OutputType.DATA_FRAME,
+        database=config.SNOWFLAKE_ANALYTICS_DATABASE,
+        schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
+    )
+    print(f"snowflake query returned {len(snowflake_result)} rows")
+
+    # transform data
+    publisher_df = transform_publisher_features.run(snowflake_result)
+
+    # load data
+    result = dataframe_to_feature_group(
+        dataframe=publisher_df,
+        feature_group_name=FEATURE_GROUP_NAME
+    )
+
+if __name__ == "__main__":
+    flow.run()

--- a/src/flows/prospecting/publisher_features.py
+++ b/src/flows/prospecting/publisher_features.py
@@ -11,7 +11,7 @@ from common_tasks.load_data import dataframe_to_feature_group
 from utils import config
 from utils.flow import get_flow_name, get_interval_schedule
 
-THREE_DAYS_MINS = 3*24*60  # using this to schedule flow update interval for three days
+ONE_DAYS_MINS = 24*60  # using this to schedule flow update interval
 VERSION = 1
 
 FEATURE_GROUP_NAME = f"{config.ENVIRONMENT}-PublisherFeatureGroup-v{VERSION}"
@@ -41,7 +41,7 @@ def transform_publisher_features(input_df: pd.DataFrame) -> pd.DataFrame:
     return input_df
 
 
-with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=THREE_DAYS_MINS), executor=LocalDaskExecutor()) as flow:
+with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=ONE_DAYS_MINS), executor=LocalDaskExecutor()) as flow:
 
     logger = prefect.context.get("logger")
     logger.info(f'Querying snowflake for publisher data')

--- a/src/flows/prospecting/publisher_features.py
+++ b/src/flows/prospecting/publisher_features.py
@@ -33,7 +33,7 @@ def transform_publisher_features(input_df: pd.DataFrame) -> pd.DataFrame:
     # remove extra column from query
     input_df = input_df.drop(columns="APPROVED_SOURCE")
 
-    # deal with rows without approved items
+    # deal with rows for sources without approved items
     approved_cols = [c for c in input_df.columns if c.startswith("NUM_APPROVED")]
     for c in approved_cols:
         input_df[c] = input_df[c].fillna(0).astype(int)

--- a/src/flows/prospecting/sql/publisher_features.sql
+++ b/src/flows/prospecting/sql/publisher_features.sql
@@ -57,6 +57,7 @@ topic_distributions AS (
     c.top_domain_name,
     t.*,
     c.save_count as total_save_count,
+    c.avg_save_age,
     c.save_count / c.num_items as avg_save_count,
     c.num_items as num_items_saved,
     LN(c.SAVE_COUNT) as log_total_saves,

--- a/src/flows/prospecting/sql/publisher_features.sql
+++ b/src/flows/prospecting/sql/publisher_features.sql
@@ -1,0 +1,66 @@
+WITH last_week_saves AS (
+  SELECT
+      c.top_domain_name,
+      count(distinct c.RESOLVED_URL) as num_items,
+      avg(d.save_count * (datediff(day, c.first_parsed_at, d.happened_at))) as avg_save_age,
+      sum(d.save_count) as save_count,
+      sum(d.open_count) AS open_count,
+      sum(d.favorite_count) AS fave_count,
+      sum(d.external_share_count) AS share_count
+  FROM ANALYTICS.DBT.CONTENT_ENGAGEMENT_BY_DAY_USER_API_ID AS d
+  JOIN ANALYTICS.DBT.CONTENT AS c
+    ON c.content_id = d.content_id
+  LEFT JOIN ANALYTICS.DBT.SCHEDULED_CORPUS_ITEMS as s
+    ON s.content_id = c.CONTENT_ID
+  WHERE d.happened_at between current_date - 7 and current_date
+    AND c.first_parsed_at between current_date - 7 and current_date
+    AND c.language = 'en'
+    AND c.word_count >= %(MIN_WORD_COUNT)s
+    AND d.save_count > 0
+    AND c.domain_id <> 5863470  -- getpocket.com
+    AND s.CONTENT_ID is NULL  -- no scheduled items
+  GROUP BY 1
+  ORDER BY save_count DESC
+  LIMIT 9000
+  ),
+
+topic_distributions AS (
+  SELECT
+      c.top_domain_name as approved_source,
+      SUM(IFF(a.topic = 'BUSINESS', 1, 0)) as num_approved_business,
+      SUM(IFF(a.topic = 'CAREER', 1, 0)) as num_approved_career,
+      SUM(IFF(a.topic = 'EDUCATION', 1, 0)) as num_approved_education,
+      SUM(IFF(a.topic = 'ENTERTAINMENT', 1, 0)) as num_approved_entertainment,
+      SUM(IFF(a.topic = 'FOOD', 1, 0)) as num_approved_food,
+      SUM(IFF(a.topic = 'GAMING', 1, 0)) as num_approved_gaming,
+      SUM(IFF(a.topic = 'HEALTH_FITNESS', 1, 0)) as num_approved_health,
+      SUM(IFF(a.topic = 'PARENTING', 1, 0)) as num_approved_parenting,
+      SUM(IFF(a.topic = 'PERSONAL_FINANCE', 1, 0)) as num_approved_personal_finance,
+      SUM(IFF(a.topic = 'POLITICS', 1, 0)) as num_approved_politics,
+      SUM(IFF(a.topic = 'SCIENCE', 1, 0)) as num_approved_science,
+      SUM(IFF(a.topic = 'SELF_IMPROVEMENT', 1, 0)) as num_approved_self_improvement,
+      SUM(IFF(a.topic = 'TECHNOLOGY', 1, 0)) as num_approved_technology,
+      SUM(IFF(a.topic = 'TRAVEL', 1, 0)) as num_approved_travel,
+      SUM(IFF(a.topic = 'SPORTS', 1, 0)) as num_approved_sports,
+      SUM(IFF(a.topic IS NOT NULL AND a.topic <> 'CORONAVIRUS', 1, 0)) as num_approved
+    FROM content as c
+    JOIN analytics.dbt.approved_corpus_items as a
+      ON a.content_id = c.content_id
+    WHERE a.topic is not NULL
+      AND a.reviewed_corpus_item_created_at > current_date - %(MAX_APPROVED_AGE)s
+    GROUP BY 1
+    ORDER BY num_approved DESC
+    LIMIT 9000
+  )
+
+  SELECT
+    c.top_domain_name,
+    t.*,
+    c.save_count as total_save_count,
+    c.save_count / c.num_items as avg_save_count,
+    c.num_items as num_items_saved,
+    LN(c.SAVE_COUNT) as log_total_saves,
+    current_timestamp as updated_at
+  FROM last_week_saves as c
+  LEFT JOIN topic_distributions as t
+    ON c.top_domain_name = t.approved_source


### PR DESCRIPTION
## Goal

Publisher diversity is a consideration in both prospecting and recommendation candidate set generation.  To start to better address this need, this flow sets up a feature group that stores features indexed by `TOP_DOMAIN_NAME` that are recomputed over time.  

The features include approval data by topic from our curators if available.  This can be used to get a sense of the topical concentration or breadth of a source.  [Adding rejection data might be interesting in a future extension]

The remaining features are save based assessments of publishers over the last week:

- total saves 
- avg days between time first parsed and item save 
- avg save count (from totals)
- log total saves
- \# of items saved 

## Implementation Decisions
 
Made a feature group instead of a snowflake model to facilitate potential access in the recommendation-api.  Otherwise relatively straightforward query and  flow.

Currently set to update daily with the save aggregations

## References

[DIS-214](https://getpocket.atlassian.net/browse/DIS-214)
[DIS-295](https://getpocket.atlassian.net/browse/DIS-295)


[DIS-214]: https://getpocket.atlassian.net/browse/DIS-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ