### PR TITLE
filter legacy curated candidate sets to en-US for ios next

### DIFF
--- a/src/flows/recommendation_api/legacy_candidate_sets/curated_feeds.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/curated_feeds.py
@@ -10,12 +10,14 @@ FLOW_NAME = get_flow_name(__file__)
 CURATED_EN_US_CANDIDATE_SET_ID = "35018233-48cd-4ec4-bcfd-7b1b1ccf30de"
 CURATED_DE_DE_CANDIDATE_SET_ID = "c66a1485-6c87-4c68-b29e-e7e838465ff7"
 CURATED_EN_US_NO_SYND_CANDIDATE_SET_ID = "493a5556-9800-449f-8f8c-c27bb6c8c810"
+COLLECTIONS_EN_US_CANDIDATE_SET_ID = "303174fc-a9ff-4a51-984a-e09ce7120d18"
 
 # Export approved corpus items by language and recency
 EXPORT_SCHEDULED_ITEMS_SQL = """
 SELECT 
     a.resolved_id as "ID", 
     a.IS_SYNDICATED as "IS_SYNDICATED",
+    a.IS_COLLECTION as "IS_COLLECTION",
     c.top_domain_name as "PUBLISHER"
 FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS" AS a
 JOIN "ANALYTICS"."DBT"."CONTENT" AS c
@@ -23,13 +25,20 @@ JOIN "ANALYTICS"."DBT"."CONTENT" AS c
 WHERE a.SCHEDULED_CORPUS_ITEM_SCHEDULED_AT BETWEEN DATEADD("day", -7, current_timestamp()) AND current_timestamp()
 AND a.SCHEDULED_SURFACE_ID = %(SCHEDULED_SURFACE)s
 ORDER BY SCHEDULED_CORPUS_ITEM_SCHEDULED_AT desc
-LIMIT 180
+LIMIT 300
 """
 
 @task()
-def transform_to_candidates(records: dict, feed_id: int, filter_synd: bool) -> List[RecommendationCandidate]:
+def transform_to_candidates(records: dict, feed_id: int, collns_only: bool=False,
+                            filter_synd: bool=True) -> List[RecommendationCandidate]:
 
-    if filter_synd:
+    if collns_only:
+        return [RecommendationCandidate(
+            item_id=rec["ID"],
+            publisher=rec["PUBLISHER"],
+            feed_id=feed_id
+        ) for rec in records if rec["IS_COLLECTION"] == 1]
+    elif filter_synd:
         return [RecommendationCandidate(
             item_id=rec["ID"],
             publisher=rec["PUBLISHER"],
@@ -52,11 +61,13 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
     )
 
     set_params = [{"SCHEDULED_SURFACE": "NEW_TAB_EN_US", "CANDIDATE_SET_ID": CURATED_EN_US_CANDIDATE_SET_ID,
-                   "FEED_ID": int(NewTabFeedID.en_US), "FILTER_SYND": False},
+                   "FEED_ID": int(NewTabFeedID.en_US), "COLLNS_ONLY": False, "FILTER_SYND": False},
                   {"SCHEDULED_SURFACE": "NEW_TAB_EN_US", "CANDIDATE_SET_ID": CURATED_EN_US_NO_SYND_CANDIDATE_SET_ID,
-                   "FEED_ID": int(NewTabFeedID.en_US), "FILTER_SYND": True},
+                   "FEED_ID": int(NewTabFeedID.en_US), "COLLNS_ONLY": False, "FILTER_SYND": True},
+                  {"SCHEDULED_SURFACE": "NEW_TAB_EN_US", "CANDIDATE_SET_ID": COLLECTIONS_EN_US_CANDIDATE_SET_ID,
+                   "FEED_ID": int(NewTabFeedID.en_US), "COLLNS_ONLY": True, "FILTER_SYND": True},
                   {"SCHEDULED_SURFACE": "NEW_TAB_DE_DE", "CANDIDATE_SET_ID": CURATED_DE_DE_CANDIDATE_SET_ID,
-                   "FEED_ID": int(NewTabFeedID.de_DE), "FILTER_SYND": False}]
+                   "FEED_ID": int(NewTabFeedID.de_DE), "COLLNS_ONLY": False, "FILTER_SYND": False}]
 
     # Fetch the most recent curated items per candidate set
     scheduled_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_SCHEDULED_ITEMS_SQL))
@@ -66,6 +77,7 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=60)) as flow:
     # post curated candidate sets to SQS
     candidate_sets = transform_to_candidates.map(valid_scheduled_candidate_items,
                                                  [p["FEED_ID"] for p in set_params],
+                                                 [p["COLLNS_ONLY"] for p in set_params],
                                                  [p["FILTER_SYND"] for p in set_params])
 
     put_results.map([p["CANDIDATE_SET_ID"] for p in set_params],

--- a/src/flows/recommendation_api/legacy_candidate_sets/longreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/longreads.py
@@ -21,6 +21,7 @@ JOIN "ANALYTICS"."DBT"."CONTENT" AS c
 WHERE a.REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD("day", -90, current_timestamp())
 AND c.WORD_COUNT >= 4500
 AND a.CORPUS_REVIEW_STATUS = 'recommendation'
+AND a.SCHEDULED_SURFACE_ID = %(SURFACE_ID)s
 AND a.LANGUAGE = %(LANG)s
 AND a.IS_SYNDICATED = 0
 ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
@@ -45,9 +46,9 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=180)) as flow:
     )
 
     set_params = [{"LANG": "EN", "CANDIDATE_SET_ID": CURATED_LONGREADS_CANDIDATE_SET_ID_EN,
-                   "FEED_ID": int(NewTabFeedID.en_US)},
+                   "SURFACE_ID": "NEW_TAB_EN_US", "FEED_ID": int(NewTabFeedID.en_US)},
                   {"LANG": "DE", "CANDIDATE_SET_ID": CURATED_LONGREADS_CANDIDATE_SET_ID_DE,
-                   "FEED_ID": int(NewTabFeedID.de_DE)}]
+                   "SURFACE_ID": "NEW_TAB_DE_DE", "FEED_ID": int(NewTabFeedID.de_DE)}]
 
     # Fetch the most recent curated longreads per langauge
     longreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_LONGREADS_ITEMS_SQL))

--- a/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
+++ b/src/flows/recommendation_api/legacy_candidate_sets/shortreads.py
@@ -21,6 +21,7 @@ JOIN "ANALYTICS"."DBT"."CONTENT" AS c
 WHERE a.REVIEWED_CORPUS_ITEM_UPDATED_AT >= DATEADD("day", -90, current_timestamp())
 AND c.WORD_COUNT <= 900
 AND a.CORPUS_REVIEW_STATUS = 'recommendation'
+AND a.SCHEDULED_SURFACE_ID = %(SURFACE_ID)s
 AND a.LANGUAGE = %(LANG)s
 AND a.IS_SYNDICATED = 0
 ORDER BY REVIEWED_CORPUS_ITEM_UPDATED_AT desc
@@ -45,9 +46,9 @@ with Flow(FLOW_NAME, schedule=get_interval_schedule(minutes=180)) as flow:
     )
 
     set_params = [{"LANG": "EN", "CANDIDATE_SET_ID": CURATED_SHORTREADS_CANDIDATE_SET_ID_EN,
-                   "FEED_ID": int(NewTabFeedID.en_US)},
+                   "SURFACE_ID": "NEW_TAB_EN_US", "FEED_ID": int(NewTabFeedID.en_US)},
                   {"LANG": "DE", "CANDIDATE_SET_ID": CURATED_SHORTREADS_CANDIDATE_SET_ID_DE,
-                   "FEED_ID": int(NewTabFeedID.de_DE)}]
+                   "SURFACE_ID": "NEW_TAB_DE_DE", "FEED_ID": int(NewTabFeedID.de_DE)}]
 
     # Fetch the most recent curated shortreads per langauge
     shortreads_candidate_items = query.map(data=set_params, query=unmapped(EXPORT_SHORTREADS_ITEMS_SQL))


### PR DESCRIPTION
## Goal
The only client using legacy recommendation-api slates rather than corpus slates is ios-next.  The current slates don't filter by the scheduled surface which is desired.    

- This PR filters curated longreads, curated shortreads, and the collections slate to include only items that are scheduled on the en-US new tab.
- The collections slate is currently powered by metaflow and we will need an additional PR in that repo to remove the metaflow code.  This PR adds candidate generation for the collections slate to the existing curated_feeds prefect flow.

## Implementation Decisions
 
- Added candidate generation for the collections slate to curated_feeds flow
- Added scheduled surface parameter to query for longreads and shortreads flows

## References

[slack](https://pocket.slack.com/archives/C01UH57EJKD/p1680718417295649)