### PR TITLE
fix(dbt_orchestration): Increase retry count and delay

### DIFF
--- a/src/flows/braze/update_flow.py
+++ b/src/flows/braze/update_flow.py
@@ -158,7 +158,7 @@ def filter_user_deltas_by_trigger(user_deltas: List[UserDelta], trigger: str) ->
     return filtered_user_deltas
 
 
-@task(max_retries=3, retry_delay=datetime.timedelta(seconds=2))
+@task(max_retries=3, retry_delay=datetime.timedelta(seconds=30))
 def delete_user_profiles(users_to_delete: List[UserDelta]):
     """
     Deletes Braze user profiles
@@ -176,7 +176,7 @@ def delete_user_profiles(users_to_delete: List[UserDelta]):
         ))
 
 
-@task(max_retries=3, retry_delay=datetime.timedelta(seconds=2))
+@task(max_retries=3, retry_delay=datetime.timedelta(seconds=30))
 def identify_users(user_deltas: List[UserDelta]):
     """
     Identifies a previously created alias-only user with an external id.
@@ -202,7 +202,7 @@ def identify_users(user_deltas: List[UserDelta]):
         ))
 
 
-@task(max_retries=3, retry_delay=datetime.timedelta(seconds=2))
+@task(max_retries=3, retry_delay=datetime.timedelta(seconds=30))
 def create_email_aliases(user_deltas: List[UserDelta]):
     """
     Creates aliases for users
@@ -238,7 +238,7 @@ def group_user_deltas_by_newsletter_subscription_name(user_deltas: List[UserDelt
     return user_deltas_by_subscription_group_name
 
 
-@task(max_retries=3, retry_delay=datetime.timedelta(seconds=2))
+@task(max_retries=3, retry_delay=datetime.timedelta(seconds=30))
 def subscribe_users(subscription_group_user_deltas: Tuple[str, List[UserDelta]]):
     """
     Subscribe users to a particular subscription group
@@ -262,7 +262,7 @@ def subscribe_users(subscription_group_user_deltas: Tuple[str, List[UserDelta]])
         )
 
 
-@task(max_retries=3, retry_delay=datetime.timedelta(seconds=2))
+@task(max_retries=3, retry_delay=datetime.timedelta(seconds=30))
 def track_users(user_deltas: List[UserDelta]):
     """
     Sends attributes and events to Braze based on UserDelta objects. Also creates new users who have an external_id.

--- a/src/flows/dbt_orchestration_flow.py
+++ b/src/flows/dbt_orchestration_flow.py
@@ -1,3 +1,5 @@
+import datetime
+
 from prefect import Flow, task
 from prefect.tasks.dbt import dbt
 from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
@@ -19,7 +21,7 @@ DBT_DOWNSTREAM_FLOW_NAMES = [
 ]
 
 
-@task(timeout=15 * 60)
+@task(timeout=15 * 60, max_retries=1, retry_delay=datetime.timedelta(seconds=60))
 def transform():
     return dbt.DbtCloudRunJob().run(cause=FLOW_NAME, job_id=DBT_CLOUD_JOB_ID, wait_for_job_run_completion=True)
 

--- a/src/flows/dbt_orchestration_flow.py
+++ b/src/flows/dbt_orchestration_flow.py
@@ -21,6 +21,8 @@ DBT_DOWNSTREAM_FLOW_NAMES = [
 ]
 
 
+# Set max_retries to 1 because this flow has a long timeout.
+# TODO: Set a concurrency-limit to prevent using more than one Dbt job resource.
 @task(timeout=15 * 60, max_retries=1, retry_delay=datetime.timedelta(seconds=60))
 def transform():
     return dbt.DbtCloudRunJob().run(cause=FLOW_NAME, job_id=DBT_CLOUD_JOB_ID, wait_for_job_run_completion=True)


### PR DESCRIPTION
## Goal
Prevent flow failures similar to those that happened on May 1st, where the Braze or Dbt API were temporarily unavailable.

## Implementation Decisions
- The 30 second delay is arbitrary. The flow ran successfully today after I retried it 5 minutes after it failed.

## References

Slack threads in #log-data-product-alerts:
* [Braze error](https://pocket.slack.com/archives/C02KH5U7G79/p1682973432171819)
* [Dbt orchestration error](https://pocket.slack.com/archives/C02KH5U7G79/p1682982079392199)
