### PR TITLE
feat: use max submission_timestamp for updated_at

### DIFF
--- a/src/flows/recommendation_api/ff_new_tab_aggregated_engagement.py
+++ b/src/flows/recommendation_api/ff_new_tab_aggregated_engagement.py
@@ -23,7 +23,7 @@ EXPORT_FIREFOX_TELEMETRY_SQL = """
         )
         SELECT
             CAST(flattened_tiles.id AS INT64) AS TILE_ID,
-            FORMAT_DATETIME("%Y-%m-%dT%H:%M:%SZ", CURRENT_DATETIME()) as UPDATED_AT,  -- Feature Store requires ISO 8601 time format
+            FORMAT_DATETIME("%Y-%m-%dT%H:%M:%SZ", MAX(submission_timestamp)) as UPDATED_AT,  -- Feature Store requires ISO 8601 time format
             COUNT(*) AS TRAILING_1_DAY_IMPRESSIONS,
             SUM(CASE WHEN click IS NOT NULL THEN 1 ELSE 0 END) AS TRAILING_1_DAY_OPENS,
             -- For now, we only need 1 day trailing data, so leave the other ones at 0.  


### PR DESCRIPTION
## Goal
To allow us to monitor and alert on the engagement pipeline latency, write timestamp we get from GCP to the Feature Store. 

Recommendation API will fetch this timestamp from the Feature Store and emit it to Snowplow.

## Implementation Decisions
- https://github.com/Pocket/data-flows/pull/214/commits/972e6944fedfef868961c66a418b81320ed71d0f Change is separately applied to the migration PR, but I didn't want to be blocked by that.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-586

Miro brainstorm diagram:
* https://miro.com/app/board/uXjVMT1rFfc=/