### PR TITLE
feat: Add alert for NewTab ranking SLO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ dask-worker-space/
 # Editors
 .idea/
 .vscode/
+.run/
 
 # VCS
 .git/

--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.2.0"
+version = "0.3.0"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/newtab/slo_newtab_ranking_flow.py
+++ b/data-products/src/newtab/slo_newtab_ranking_flow.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta
+from typing import Dict
+
+from common.databases.snowflake_utils import PktSnowflakeConnector
+from common.deployment import FlowSpec, FlowDeployment
+from prefect import task, flow
+from prefect.blocks.notifications import PagerDutyWebHook
+from prefect.server.schemas.schedules import CronSchedule
+from prefect_snowflake.database import snowflake_query
+from snowflake.connector import DictCursor
+
+from shared.blocks.notifications.pagerduty import get_notification_block
+
+# 0.95 means that the alarm goes off if < 95% of the error budget remains.
+ERROR_BUDGET_ALARM_THRESHOLD = 0.95
+# Alarm goes off if data points are missing for this duration.
+MISSING_DATA_ALARM_THRESHOLD = timedelta(seconds=3600)
+SLO_NAME = "NewTab Recommendation Ranking SLO"
+
+
+METRIC_QUERY = """
+select 
+    TRUNCATED_RECOMMENDED_AT,
+    ERROR_BUDGET
+from ANALYTICS.DBT_FACTS.NEWTAB_RECOMMENDATION_RANKING_FRESHNESS_SLO
+order by TRUNCATED_RECOMMENDED_AT desc
+limit 1
+"""
+
+
+@flow()
+async def slo_newtab_ranking_flow():
+    metrics = snowflake_query(
+        snowflake_connector=PktSnowflakeConnector(),
+        query=METRIC_QUERY,
+        cursor_type=DictCursor,
+    )[0]
+
+    notifier = await get_notification_block(notification_type="non-critical")
+    notify_if_error_budget_is_low(metrics, notifier)
+    notify_if_data_points_are_missing(metrics, notifier)
+
+
+@task()
+async def notify_if_error_budget_is_low(metrics: Dict, notifier: PagerDutyWebHook):
+    error_budget = metrics["ERROR_BUDGET"]
+
+    if error_budget < ERROR_BUDGET_ALARM_THRESHOLD:
+        await notifier.notify(
+            subject=f"{SLO_NAME} error budget is {error_budget:.1%}",
+            body="Runbook: https://getpocket.atlassian.net/l/cp/juY9UDqV",
+        )
+
+
+@task()
+async def notify_if_data_points_are_missing(metrics: Dict, notifier):
+    truncated_recommended_at = metrics["TRUNCATED_RECOMMENDED_AT"]
+    data_age = datetime.now() - datetime.fromisoformat(truncated_recommended_at)
+
+    if data_age > MISSING_DATA_ALARM_THRESHOLD:
+        await notifier.notify(
+            subject=f"{SLO_NAME} is missing data points",
+            body=f"Most recent row is {data_age.total_seconds() / 60:.0f} minutes old",
+        )
+
+
+FLOW_SPEC = FlowSpec(
+    flow=slo_newtab_ranking_flow,
+    docker_env="base",
+    deployments=[
+        FlowDeployment(
+            deployment_name="base",
+            # Business hour schedule: At minute 0 from 8am PST through 5pm PST, from Monday through Friday.
+            schedule=CronSchedule(
+                cron="0 8-17 * * 1-5", timezone="America/Los_Angeles"
+            ),
+        ),
+    ],
+)
+
+
+if __name__ == "__main__":
+    slo_newtab_ranking_flow()

--- a/data-products/src/newtab/slo_newtab_ranking_flow.py
+++ b/data-products/src/newtab/slo_newtab_ranking_flow.py
@@ -53,7 +53,7 @@ async def notify_if_error_budget_is_low(metrics: Dict, notifier: PagerDutyWebHoo
 
 
 @task()
-async def notify_if_data_points_are_missing(metrics: Dict, notifier):
+async def notify_if_data_points_are_missing(metrics: Dict, notifier: PagerDutyWebHook):
     truncated_recommended_at = metrics["TRUNCATED_RECOMMENDED_AT"]
     data_age = datetime.now() - datetime.fromisoformat(truncated_recommended_at)
 

--- a/data-products/tests/newtab/test_slo_newtab_ranking_flow.py
+++ b/data-products/tests/newtab/test_slo_newtab_ranking_flow.py
@@ -1,0 +1,61 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytest
+from prefect.blocks.abstract import NotificationBlock
+
+from newtab.slo_newtab_ranking_flow import (
+    notify_if_error_budget_is_low,
+    notify_if_data_points_are_missing,
+)
+
+
+class DummyNotifier(NotificationBlock):
+    def __init__(self):
+        self.notifications = []
+
+    async def notify(self, body: str, subject: Optional[str] = None) -> None:
+        self.notifications.append((subject, body))
+
+
+@pytest.fixture()
+def notifier_fixture():
+    return DummyNotifier()
+
+
+@pytest.mark.asyncio
+async def test_error_budget_high(notifier_fixture):
+    await notify_if_error_budget_is_low.fn({"ERROR_BUDGET": 0.99}, notifier_fixture)
+    assert len(notifier_fixture.notifications) == 0
+
+
+@pytest.mark.asyncio
+async def test_error_budget_low(notifier_fixture):
+    await notify_if_error_budget_is_low.fn({"ERROR_BUDGET": 0.6789}, notifier_fixture)
+
+    assert len(notifier_fixture.notifications) == 1
+    subject, body = notifier_fixture.notifications[0]
+    assert "error budget is 67.9%" in subject
+
+
+@pytest.mark.asyncio
+async def test_data_points_not_missing(notifier_fixture):
+    metrics = {
+        "TRUNCATED_RECOMMENDED_AT": (datetime.now() - timedelta(minutes=50)).isoformat()
+    }
+    await notify_if_data_points_are_missing.fn(metrics, notifier_fixture)
+
+    assert len(notifier_fixture.notifications) == 0
+
+
+@pytest.mark.asyncio
+async def test_data_points_missing(notifier_fixture):
+    metrics = {
+        "TRUNCATED_RECOMMENDED_AT": (datetime.now() - timedelta(minutes=70)).isoformat()
+    }
+    await notify_if_data_points_are_missing.fn(metrics, notifier_fixture)
+
+    assert len(notifier_fixture.notifications) == 1
+    subject, body = notifier_fixture.notifications[0]
+    assert "missing data points" in subject
+    assert body == "Most recent row is 70 minutes old"


### PR DESCRIPTION
## Goal
Notify Data Products if NewTab is ranked with stale engagement data. Based on the 10% error budget defined in the [SLO](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2927099995/Fx+NewTab+for+New+Markets+Reliability+Doc), we should aim to resolve this alert in 1 business day.

## Implementation Decisions
- Prefect uses the [apprise](https://github.com/caronc/apprise) library for PagerDuty integration. This library only supports a `notify` action, and cannot resolve PagerDuty alerts. That's probably fine for our use-case. This flow will send out a non-critical PagerDuty alert every time it's run, if the SLO threshold is breached or is missing data. It's scheduled to run every hour during business hours, to avoid notifications stacking up during off hours.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/DIS-590

SLO Mode report:
- https://app.mode.com/getpocket/reports/11dcc2b47f64

Documentation:
* [Tech Spec](https://getpocket.atlassian.net/wiki/spaces/CP/pages/2924052481/Technical+Spec+Firefox+Recommendation+API)