### PR TITLE
fix:fixing unit tests to work for all deployment types

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -106,7 +106,7 @@ commands:
             for env in "dev" "staging" "main"
             do
               export DF_CONFIG_DEPLOYMENT_TYPE=$env
-              echo "Running unit tests for deployment type: $env ..."
+              echo "Running unit tests for deployment type: $env..."
               poetry run python -m pytest -vvvs --cov=<<parameters.coverage_path>> --cov-report term-missing --cov-fail-under=100 <<parameters.tests_path>>
             done
           name: Python Testing and Validation

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -103,7 +103,12 @@ commands:
             then
               poetry run deploy-cli --check-version
             fi
-            poetry run python -m pytest -vvvs --cov=<<parameters.coverage_path>> --cov-report term-missing --cov-fail-under=100 <<parameters.tests_path>>
+            for env in "dev" "staging" "main"
+            do
+              export DF_CONFIG_DEPLOYMENT_TYPE=$env
+              echo "Running unit tests for deployment type: $env ..."
+              poetry run python -m pytest -vvvs --cov=<<parameters.coverage_path>> --cov-report term-missing --cov-fail-under=100 <<parameters.tests_path>>
+            done
           name: Python Testing and Validation
   # shortcut for the common_utils_build.sh script
   common_utils_wheel_file:

--- a/common-utils/pyproject.toml
+++ b/common-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "common-utils"
-version = "0.3.2"
+version = "0.3.3"
 description = "Shared modules for prefect flow development and deployment"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/common-utils/run_pytest.sh
+++ b/common-utils/run_pytest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Bash script for running unit test suite once per deployment type
+
+set -e
+
+for env in "dev" "staging" "main"
+do
+    export DF_CONFIG_DEPLOYMENT_TYPE=$env
+    echo "Running unit tests for deployment type: $env ..."
+    poetry run python -m pytest -s -vvv --cov=src --cov-report term-missing --cov-fail-under=100
+done

--- a/common-utils/run_pytest.sh
+++ b/common-utils/run_pytest.sh
@@ -7,6 +7,6 @@ set -e
 for env in "dev" "staging" "main"
 do
     export DF_CONFIG_DEPLOYMENT_TYPE=$env
-    echo "Running unit tests for deployment type: $env ..."
+    echo "Running unit tests for deployment type: $env..."
     poetry run python -m pytest -s -vvv --cov=src --cov-report term-missing --cov-fail-under=100
 done

--- a/common-utils/tests/databases/unit/test_snowflake_utils.py
+++ b/common-utils/tests/databases/unit/test_snowflake_utils.py
@@ -1,14 +1,17 @@
 from pathlib import PosixPath
 from unittest.mock import patch
 
-from prefect import flow
-from pydantic import SecretStr
-
 from common.databases.snowflake_utils import (
     PktSnowflakeConnector,
     get_gcs_stage,
     get_pocket_snowflake_connector_block,
 )
+from common.settings import CommonSettings
+from prefect import flow
+from pydantic import SecretStr
+
+CS = CommonSettings()  # type: ignore
+DB_MAPPING = {"dev": "development", "production": "prefect"}
 
 
 def test_pkt_snowflake_connector():
@@ -20,7 +23,7 @@ def test_pkt_snowflake_connector():
     assert x.credentials.private_key_path == PosixPath("tmp/test.p8")
     assert isinstance(x.credentials.private_key_passphrase, SecretStr)
     assert x.credentials.role == "test"
-    assert x.database == "development"
+    assert x.database == DB_MAPPING[CS.dev_or_production]
     assert x.warehouse == "prefect_wh_test"
     assert x.schema_ == "test"
 
@@ -69,7 +72,7 @@ def test_get_pocket_snowflake_connector_block():
     assert x.credentials.private_key_path == PosixPath("tmp/test.p8")
     assert isinstance(x.credentials.private_key_passphrase, SecretStr)
     assert x.credentials.role == "test"
-    assert x.database == "development"
+    assert x.database == DB_MAPPING[CS.dev_or_production]
     assert x.warehouse == "prefect_wh_test"
     assert x.schema_ == "test"
 
@@ -90,6 +93,6 @@ def test_get_pocket_snowflake_connector_block_overrides():
     assert x.credentials.private_key_path == PosixPath("tmp/test.p8")
     assert isinstance(x.credentials.private_key_passphrase, SecretStr)
     assert x.credentials.role == "test"
-    assert x.database == "development"
+    assert x.database == DB_MAPPING[CS.dev_or_production]
     assert x.warehouse == "prefect_wh_override"
     assert x.schema_ == "override"

--- a/common-utils/tests/deployment/unit/test_deployment.py
+++ b/common-utils/tests/deployment/unit/test_deployment.py
@@ -371,6 +371,7 @@ def test_flow_spec_all_fields(mock_ecs_save, mock_deployment):
 
 
 @mock_ecs
+@patch("common.deployment.DEPLOYMENT_TYPE", "dev")
 @patch("common.deployment.FlowDeployment.push_deployment")
 @patch("prefect_aws.ecs.ECSTask.save")
 def test_flow_spec_bad_env(mock_ecs_save, mock_deployment):

--- a/common-utils/tests/unit/test_settings.py
+++ b/common-utils/tests/unit/test_settings.py
@@ -1,3 +1,5 @@
+import os
+
 from common.settings import CommonSettings, NestedSettings, Settings
 
 
@@ -32,6 +34,9 @@ def test_nested():
 
 def test_common_settings():
     cs = CommonSettings()  # type: ignore
+    if x := os.getenv("DF_CONFIG_DEPLOYMENT_TYPE"):
+        assert x == cs.deployment_type
+    cs.deployment_type = "dev"
     assert cs.deployment_type == "dev"
     assert cs.is_production is False
     assert cs.dev_or_production == "dev"
@@ -45,4 +50,5 @@ def test_common_settings_not_dev():
     assert cs.is_production is True
     assert cs.dev_or_production == "production"
     x = cs.deployment_type_value("dev", "staging", "main")
+    assert x == "main"
     assert x == "main"

--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.4.1"
+version = "0.4.2"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/tests/sql_etl/unit/test_run_jobs_flow.py
+++ b/data-products/tests/sql_etl/unit/test_run_jobs_flow.py
@@ -53,7 +53,7 @@ def test_sql_job():
     offset_persist = SQL_JOB_TEST_DATETIME.add(hours=19).to_iso8601_string()
     assert (
         t.get_extraction_sql(interval_input)
-        == f"copy into '@DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_DEV/test/{interval_input.partition_folders}/data'\n        from (SELECT\n\n    *   \n\nFROM \n\nfrom \n\nwhere updated_at >= '{interval_input.batch_start}'\nand updated_at < '{interval_input.batch_end}')\n        header = true\n        overwrite = true\n        max_file_size = 104857600"  # noqa: E501
+        == f"copy into '{t.get_snowflake_stage_uri(interval_input)}/data'\n        from (SELECT\n\n    *   \n\nFROM \n\nfrom \n\nwhere updated_at >= '{interval_input.batch_start}'\nand updated_at < '{interval_input.batch_end}')\n        header = true\n        overwrite = true\n        max_file_size = 104857600"  # noqa: E501
     )
     assert (
         t.get_last_offset_sql()
@@ -61,7 +61,7 @@ def test_sql_job():
     )
     assert (
         t.get_load_sql(interval_input)
-        == f"copy into test.test.test (\n              batch_id,\n              updated_at,\n              data,\n              _gs_file_name,\n            _gs_file_row_number,\n            _gs_file_date,\n            _gs_file_time,\n            _loaded_at\n            )\n        from (\n            select\n                {interval_input.partition_timestamp},\n                $1:updated_at as updated_at,\n                $1 as data,\n                metadata$filename,\n            metadata$file_row_number,\n            split_part(metadata$filename,'/', -2),\n            split_part(metadata$filename,'/', -1),\n            sysdate()\n            from @DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_DEV/test/{interval_input.partition_folders}\n        )\n        file_format = (type = 'PARQUET')"  # noqa: E501
+        == f"copy into test.test.test (\n              batch_id,\n              updated_at,\n              data,\n              _gs_file_name,\n            _gs_file_row_number,\n            _gs_file_date,\n            _gs_file_time,\n            _loaded_at\n            )\n        from (\n            select\n                {interval_input.partition_timestamp},\n                $1:updated_at as updated_at,\n                $1 as data,\n                metadata$filename,\n            metadata$file_row_number,\n            split_part(metadata$filename,'/', -2),\n            split_part(metadata$filename,'/', -1),\n            sysdate()\n            from {t.get_snowflake_stage_uri(interval_input)}\n        )\n        file_format = (type = 'PARQUET')"  # noqa: E501
     )
     assert (
         t.get_new_offset_sql(interval_input)
@@ -109,7 +109,7 @@ def test_sql_job_external_state_biqquery():
     )
     assert (
         t.get_load_sql(interval_input)
-        == f"copy into test.test.test (\n              batch_id,\n              updated_at,\n              data,\n              _gs_file_name,\n            _gs_file_row_number,\n            _gs_file_date,\n            _gs_file_time,\n            _loaded_at\n            )\n        from (\n            select\n                {interval_input.partition_timestamp},\n                $1:updated_at as updated_at,\n                $1 as data,\n                metadata$filename,\n            metadata$file_row_number,\n            split_part(metadata$filename,'/', -2),\n            split_part(metadata$filename,'/', -1),\n            sysdate()\n            from @DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_DEV/test/{interval_input.partition_folders}\n        )\n        file_format = (type = 'PARQUET')"  # noqa: E501
+        == f"copy into test.test.test (\n              batch_id,\n              updated_at,\n              data,\n              _gs_file_name,\n            _gs_file_row_number,\n            _gs_file_date,\n            _gs_file_time,\n            _loaded_at\n            )\n        from (\n            select\n                {interval_input.partition_timestamp},\n                $1:updated_at as updated_at,\n                $1 as data,\n                metadata$filename,\n            metadata$file_row_number,\n            split_part(metadata$filename,'/', -2),\n            split_part(metadata$filename,'/', -1),\n            sysdate()\n            from {t.get_snowflake_stage_uri(interval_input)}\n        )\n        file_format = (type = 'PARQUET')"  # noqa: E501
     )  # noqa: E501
     assert (
         t.get_new_offset_sql(interval_input)


### PR DESCRIPTION
small change to update unit test running to go once per deployment type

this update was applied to the circleci command that runs them

also created and helper script that be run from any project with `../common-utils/run_pytest.sh`

finally updated data-products unit tests to reflect this change.

https://getpocket.atlassian.net/browse/DIS-830