### PR TITLE
fix: fixing issues with dynamic setting of the sql template path and fixing interval schedules in deployment

### DIFF
--- a/common-utils/poetry.lock
+++ b/common-utils/poetry.lock
@@ -1818,14 +1818,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prefect"
-version = "2.10.10"
+version = "2.10.17"
 description = "Workflow orchestration and management."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "prefect-2.10.10-py3-none-any.whl", hash = "sha256:95ac36ded34dfcd53ded5c42d76425a90ed403543319d47674d736cccb3021ff"},
-    {file = "prefect-2.10.10.tar.gz", hash = "sha256:45f51fb0e56a18c6b182d1b14877b11eb5ded73939f5ada4630afab8315eb394"},
+    {file = "prefect-2.10.17-py3-none-any.whl", hash = "sha256:632a9c149cf4d9ff917a66916d2d4939059b5f9c41372b8f082a5b87f9c5c669"},
+    {file = "prefect-2.10.17.tar.gz", hash = "sha256:490fc6ebbad72d451feb493a112a8d38d9c7eb3981d8f67a231a9770744a3d43"},
 ]
 
 [package.dependencies]
@@ -1860,7 +1860,8 @@ pytz = ">=2021.1"
 pyyaml = ">=5.4.1"
 readchar = ">=4.0.0"
 rich = ">=11.0"
-sqlalchemy = {version = ">=1.4.22,<1.4.33 || >1.4.33,<2.0", extras = ["asyncio"]}
+ruamel-yaml = ">=0.17.0"
+sqlalchemy = {version = ">=1.4.22,<1.4.33 || >1.4.33", extras = ["asyncio"]}
 toml = ">=0.10.0"
 typer = ">=0.4.2"
 typing-extensions = ">=4.1.0"
@@ -2626,6 +2627,72 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.17.32"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+category = "main"
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "ruamel.yaml-0.17.32-py3-none-any.whl", hash = "sha256:23cd2ed620231677564646b0c6a89d138b6822a0d78656df7abda5879ec4f447"},
+    {file = "ruamel.yaml-0.17.32.tar.gz", hash = "sha256:ec939063761914e14542972a5cba6d33c23b0859ab6342f61cf070cfc600efc2"},
+]
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.12\""}
+
+[package.extras]
+docs = ["ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.7"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5859983f26d8cd7bb5c287ef452e8aacc86501487634573d260968f753e1d71"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:debc87a9516b237d0466a711b18b6ebeb17ba9f391eb7f91c649c5c4ec5006c7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:df5828871e6648db72d1c19b4bd24819b80a755c4541d3409f0f7acd0f335c80"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:efa08d63ef03d079dcae1dfe334f6c8847ba8b645d08df286358b1f5293d24ab"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:370445fd795706fd291ab00c9df38a0caed0f17a6fb46b0f607668ecb16ce763"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win32.whl", hash = "sha256:ecdf1a604009bd35c674b9225a8fa609e0282d9b896c03dd441a91e5f53b534e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win_amd64.whl", hash = "sha256:f34019dced51047d6f70cb9383b2ae2853b7fc4dce65129a5acd49f4f9256646"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2aa261c29a5545adfef9296b7e33941f46aa5bbd21164228e833412af4c9c75f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f01da5790e95815eb5a8a138508c01c758e5f5bc0ce4286c4f7028b8dd7ac3d0"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:40d030e2329ce5286d6b231b8726959ebbe0404c92f0a578c0e2482182e38282"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c3ca1fbba4ae962521e5eb66d72998b51f0f4d0f608d3c0347a48e1af262efa7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win32.whl", hash = "sha256:7bdb4c06b063f6fd55e472e201317a3bb6cdeeee5d5a38512ea5c01e1acbdd93"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win_amd64.whl", hash = "sha256:be2a7ad8fd8f7442b24323d24ba0b56c51219513cfa45b9ada3b87b76c374d4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91a789b4aa0097b78c93e3dc4b40040ba55bef518f84a40d4442f713b4094acb"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:99e77daab5d13a48a4054803d052ff40780278240a902b880dd37a51ba01a307"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3243f48ecd450eddadc2d11b5feb08aca941b5cd98c9b1db14b2fd128be8c697"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8831a2cedcd0f0927f788c5bdf6567d9dc9cc235646a434986a852af1cb54b4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win32.whl", hash = "sha256:3110a99e0f94a4a3470ff67fc20d3f96c25b13d24c6980ff841e82bafe827cac"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win_amd64.whl", hash = "sha256:92460ce908546ab69770b2e576e4f99fbb4ce6ab4b245345a3869a0a0410488f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5bc0667c1eb8f83a3752b71b9c4ba55ef7c7058ae57022dd9b29065186a113d9"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:4a4d8d417868d68b979076a9be6a38c676eca060785abaa6709c7b31593c35d1"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf9a6bc4a0221538b1a7de3ed7bca4c93c02346853f44e1cd764be0023cd3640"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a7b301ff08055d73223058b5c46c55638917f04d21577c95e00e0c4d79201a6b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win32.whl", hash = "sha256:d5e51e2901ec2366b79f16c2299a03e74ba4531ddcfacc1416639c557aef0ad8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:184faeaec61dbaa3cace407cffc5819f7b977e75360e8d5ca19461cd851a5fc5"},
+    {file = "ruamel.yaml.clib-0.2.7.tar.gz", hash = "sha256:1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"},
+]
 
 [[package]]
 name = "s3transfer"

--- a/common-utils/pyproject.toml
+++ b/common-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "common-utils"
-version = "0.3.3"
+version = "0.3.4"
 description = "Shared modules for prefect flow development and deployment"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/common-utils/tests/deployment/unit/test_deployment.py
+++ b/common-utils/tests/deployment/unit/test_deployment.py
@@ -179,9 +179,10 @@ def test_flow_deployment(mock_cmd):
         flow_function_name="test_function",
         flow_name="test.test.test",
         pythonpath_addition=TEST_PYTHONPATH,
+        base_envars={"TEST": "test"}
     )
     assert mock_cmd.call_count == 1
-    call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-main \\\n        -sb github/data-flows-main/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-main \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t main \\\n        -a \\\n        --interval 120 --skip-upload && \\\n        popd"""
+    call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-main \\\n        -sb github/data-flows-main/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override env.TEST=test --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-main \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t main \\\n        -a \\\n        --interval 120 --skip-upload && \\\n        popd"""
     mock_cmd.assert_called_with(call_text)
 
 
@@ -217,9 +218,10 @@ def test_flow_deployment_prod_test(mock_cmd):
         flow_function_name="test_function",
         flow_name="test.test.test",
         pythonpath_addition=TEST_PYTHONPATH,
+        base_envars={"TEST": "test"}
     )
     assert mock_cmd.call_count == 1
-    call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-staging \\\n        -sb github/data-flows-staging/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-staging \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t staging \\\n        -a \\\n         --skip-upload && \\\n        popd"""
+    call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-staging \\\n        -sb github/data-flows-staging/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override env.TEST=test --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-staging \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t staging \\\n        -a \\\n         --skip-upload && \\\n        popd"""
     mock_cmd.assert_called_with(call_text)
 
 
@@ -255,9 +257,10 @@ def test_flow_deployment_dev_test(mock_cmd):
         flow_function_name="test_function",
         flow_name="test.test.test",
         pythonpath_addition=TEST_PYTHONPATH,
+        base_envars={"TEST": "test"}
     )
     assert mock_cmd.call_count == 1
-    call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-dev \\\n        -sb github/data-flows-dev/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-dev \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t dev \\\n        -a \\\n         --skip-upload && \\\n        popd"""
+    call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-dev \\\n        -sb github/data-flows-dev/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override env.TEST=test --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-dev \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t dev \\\n        -a \\\n         --skip-upload && \\\n        popd"""
     mock_cmd.assert_called_with(call_text)
 
 
@@ -298,6 +301,7 @@ def test_flow_spec(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {}
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -364,6 +368,7 @@ def test_flow_spec_all_fields(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {}
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -391,6 +396,11 @@ def test_flow_spec_bad_env(mock_ecs_save, mock_deployment):
         secrets=[
             FlowEnvar(
                 envar_name="MY_SECRET_JSON", envar_value="/my/secretsmanager/secret"
+            )
+        ],
+        envars=[
+            FlowEnvar(
+                envar_name="TEST", envar_value="test"
             )
         ],
         ephemeral_storage_gb=200,
@@ -429,6 +439,7 @@ def test_flow_spec_bad_env(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {"TEST": "test"}
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -547,6 +558,7 @@ def test_flow_spec_handle_task_definition(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {}
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -626,6 +638,7 @@ def test_flow_spec_handle_task_definition_container_change(
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {}
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -702,6 +715,7 @@ def test_flow_spec_handle_task_definition_state_change(mock_ecs_save, mock_deplo
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {}
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True

--- a/common-utils/tests/deployment/unit/test_deployment.py
+++ b/common-utils/tests/deployment/unit/test_deployment.py
@@ -179,7 +179,7 @@ def test_flow_deployment(mock_cmd):
         flow_function_name="test_function",
         flow_name="test.test.test",
         pythonpath_addition=TEST_PYTHONPATH,
-        base_envars={"TEST": "test"}
+        base_envars={"TEST": "test"},
     )
     assert mock_cmd.call_count == 1
     call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-main \\\n        -sb github/data-flows-main/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override env.TEST=test --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-main \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t main \\\n        -a \\\n        --interval 120 --skip-upload && \\\n        popd"""
@@ -218,7 +218,7 @@ def test_flow_deployment_prod_test(mock_cmd):
         flow_function_name="test_function",
         flow_name="test.test.test",
         pythonpath_addition=TEST_PYTHONPATH,
-        base_envars={"TEST": "test"}
+        base_envars={"TEST": "test"},
     )
     assert mock_cmd.call_count == 1
     call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-staging \\\n        -sb github/data-flows-staging/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override env.TEST=test --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-staging \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t staging \\\n        -a \\\n         --skip-upload && \\\n        popd"""
@@ -257,7 +257,7 @@ def test_flow_deployment_dev_test(mock_cmd):
         flow_function_name="test_function",
         flow_name="test.test.test",
         pythonpath_addition=TEST_PYTHONPATH,
-        base_envars={"TEST": "test"}
+        base_envars={"TEST": "test"},
     )
     assert mock_cmd.call_count == 1
     call_text = f"""export POCKET_PREFECT_FLOW_NAME=test.test.test && \\\n        export PYTHONPATH={TEST_PYTHONPATH} && \\\n        pushd ../ && \\\n        prefect deployment build common-utils/tests/deployment/unit/test_deployment.py:test_function \\\n        -n test-dev \\\n        -sb github/data-flows-dev/common-utils/tests/deployment/unit \\\n        -ib ecs-task/test-ECS-block \\\n        --override env.TEST=test --override \'task_customizations=[{{"op": "add", "path": "/overrides/cpu", "value": "1024"}}, {{"op": "add", "path": "/overrides/memory", "value": "4096"}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/subnets", "value": ["subnet-1234", "subnet-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/securityGroups", "value": ["sg-1234"]}}, {{"op": "add", "path": "/networkConfiguration/awsvpcConfiguration/assignPublicIp", "value": "DISABLED"}}]\' \\\n        -q prefect-v2-queue-dev \\\n        -v {GIT_SHA} \\\n        --params \'{{"test_param": "test_value"}}\' \\\n        -t test -t unit -t dev \\\n        -a \\\n         --skip-upload && \\\n        popd"""
@@ -301,7 +301,7 @@ def test_flow_spec(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {}
+        {},
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -368,7 +368,7 @@ def test_flow_spec_all_fields(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {}
+        {},
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -398,11 +398,7 @@ def test_flow_spec_bad_env(mock_ecs_save, mock_deployment):
                 envar_name="MY_SECRET_JSON", envar_value="/my/secretsmanager/secret"
             )
         ],
-        envars=[
-            FlowEnvar(
-                envar_name="TEST", envar_value="test"
-            )
-        ],
+        envars=[FlowEnvar(envar_name="TEST", envar_value="test")],
         ephemeral_storage_gb=200,
         deployments=[
             FlowDeployment(
@@ -439,7 +435,7 @@ def test_flow_spec_bad_env(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {"TEST": "test"}
+        {"TEST": "test"},
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -558,7 +554,7 @@ def test_flow_spec_handle_task_definition(mock_ecs_save, mock_deployment):
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {}
+        {},
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -638,7 +634,7 @@ def test_flow_spec_handle_task_definition_container_change(
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {}
+        {},
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True
@@ -715,7 +711,7 @@ def test_flow_spec_handle_task_definition_state_change(mock_ecs_save, mock_deplo
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {}
+        {},
     )
     mock_ecs_save.assert_called_with(
         "common-utils-flow-group-1-flow-1-dev", overwrite=True

--- a/common-utils/tests/deployment/unit/test_deployment.py
+++ b/common-utils/tests/deployment/unit/test_deployment.py
@@ -5,9 +5,6 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from boto3 import session
-from moto import mock_ecs, mock_sts
-from prefect import flow, task
-
 from common.deployment import (
     GIT_SHA,
     CronSchedule,
@@ -24,6 +21,8 @@ from common.deployment import (
     get_pyproject_metadata,
     run_command,
 )
+from moto import mock_ecs, mock_sts
+from prefect import flow, task
 
 TEST_PYTHONPATH = os.path.expanduser(os.path.join(os.getcwd(), "tests/test_flows"))
 
@@ -151,9 +150,9 @@ def test_flow_deployment(mock_cmd):
     d1 = FlowDeployment(deployment_name="test", schedule=CronSchedule(cron="0 0 * * *"))  # type: ignore
     x1 = d1._get_schedule_arg()
     assert x1 == "--cron '0 0 * * *'"
-    d2 = FlowDeployment(deployment_name="test", schedule=IntervalSchedule(interval=60))  # type: ignore
+    d2 = FlowDeployment(deployment_name="test", schedule=IntervalSchedule(interval=timedelta(days=2)))  # type: ignore
     x2 = d2._get_schedule_arg()
-    assert x2 == "--interval 60"
+    assert x2 == "--interval 172800"
     d3 = FlowDeployment(deployment_name="test", schedule=RRuleSchedule(rrule="FREQ=HOURLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=9,10,11,12,13,14,15,16,17"))  # type: ignore
     x3 = d3._get_schedule_arg()
     assert (
@@ -609,11 +608,11 @@ def test_flow_spec_handle_task_definition_container_change(
                 schedule=CronSchedule(cron="0 0 * * *"),
             ),  # type: ignore
             FlowDeployment(
-                deployment_name="hourly",
+                deployment_name="daily",
                 cpu="1024",
                 memory="4096",
                 parameters={"param_name": "param_value"},
-                schedule=IntervalSchedule(interval=timedelta(hours=1)),
+                schedule=IntervalSchedule(interval=timedelta(days=1)),
             ),  # type: ignore
         ],  # type: ignore
     )

--- a/common-utils/tests/deployment/unit/test_deployment_disable_inf.py
+++ b/common-utils/tests/deployment/unit/test_deployment_disable_inf.py
@@ -40,6 +40,11 @@ def test_flow_spec_disable_handle_task_definition(mock_ecs_save, mock_deployment
                 envar_name="MY_SECRET_JSON", envar_value="/my/secretsmanager/secret"
             )
         ],
+        envars=[
+            FlowEnvar(
+                envar_name="TEST", envar_value="test"
+            )
+        ],
         ephemeral_storage_gb=50,
         deployments=[
             FlowDeployment(
@@ -75,4 +80,5 @@ def test_flow_spec_disable_handle_task_definition(mock_ecs_save, mock_deployment
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
+        {"TEST": "test"}
     )

--- a/common-utils/tests/deployment/unit/test_deployment_disable_inf.py
+++ b/common-utils/tests/deployment/unit/test_deployment_disable_inf.py
@@ -40,11 +40,7 @@ def test_flow_spec_disable_handle_task_definition(mock_ecs_save, mock_deployment
                 envar_name="MY_SECRET_JSON", envar_value="/my/secretsmanager/secret"
             )
         ],
-        envars=[
-            FlowEnvar(
-                envar_name="TEST", envar_value="test"
-            )
-        ],
+        envars=[FlowEnvar(envar_name="TEST", envar_value="test")],
         ephemeral_storage_gb=50,
         deployments=[
             FlowDeployment(
@@ -80,5 +76,5 @@ def test_flow_spec_disable_handle_task_definition(mock_ecs_save, mock_deployment
         "flow_1",
         "common-utils.flow-group-1.flow-1",
         TEST_PYTHONPATH,
-        {"TEST": "test"}
+        {"TEST": "test"},
     )

--- a/data-products/poetry.lock
+++ b/data-products/poetry.lock
@@ -2097,14 +2097,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "prefect"
-version = "2.10.13"
+version = "2.10.17"
 description = "Workflow orchestration and management."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "prefect-2.10.13-py3-none-any.whl", hash = "sha256:6e497c5549b7c4238ddf736f7c38fcbe0cac1a3fc822aa0f481cf76485d2677d"},
-    {file = "prefect-2.10.13.tar.gz", hash = "sha256:a9294aea081c7f416cef41e99fe584f656d6d9a6dafc37633343e25ee69f9136"},
+    {file = "prefect-2.10.17-py3-none-any.whl", hash = "sha256:632a9c149cf4d9ff917a66916d2d4939059b5f9c41372b8f082a5b87f9c5c669"},
+    {file = "prefect-2.10.17.tar.gz", hash = "sha256:490fc6ebbad72d451feb493a112a8d38d9c7eb3981d8f67a231a9770744a3d43"},
 ]
 
 [package.dependencies]
@@ -2139,6 +2139,7 @@ pytz = ">=2021.1"
 pyyaml = ">=5.4.1"
 readchar = ">=4.0.0"
 rich = ">=11.0"
+ruamel-yaml = ">=0.17.0"
 sqlalchemy = {version = ">=1.4.22,<1.4.33 || >1.4.33", extras = ["asyncio"]}
 toml = ">=0.10.0"
 typer = ">=0.4.2"
@@ -2991,6 +2992,72 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.17.32"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+category = "main"
+optional = false
+python-versions = ">=3"
+files = [
+    {file = "ruamel.yaml-0.17.32-py3-none-any.whl", hash = "sha256:23cd2ed620231677564646b0c6a89d138b6822a0d78656df7abda5879ec4f447"},
+    {file = "ruamel.yaml-0.17.32.tar.gz", hash = "sha256:ec939063761914e14542972a5cba6d33c23b0859ab6342f61cf070cfc600efc2"},
+]
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.12\""}
+
+[package.extras]
+docs = ["ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.7"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5859983f26d8cd7bb5c287ef452e8aacc86501487634573d260968f753e1d71"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:debc87a9516b237d0466a711b18b6ebeb17ba9f391eb7f91c649c5c4ec5006c7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:df5828871e6648db72d1c19b4bd24819b80a755c4541d3409f0f7acd0f335c80"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:efa08d63ef03d079dcae1dfe334f6c8847ba8b645d08df286358b1f5293d24ab"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
+    {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4b3a93bb9bc662fc1f99c5c3ea8e623d8b23ad22f861eb6fce9377ac07ad6072"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-macosx_12_0_arm64.whl", hash = "sha256:a234a20ae07e8469da311e182e70ef6b199d0fbeb6c6cc2901204dd87fb867e8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:15910ef4f3e537eea7fe45f8a5d19997479940d9196f357152a09031c5be59f3"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:370445fd795706fd291ab00c9df38a0caed0f17a6fb46b0f607668ecb16ce763"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win32.whl", hash = "sha256:ecdf1a604009bd35c674b9225a8fa609e0282d9b896c03dd441a91e5f53b534e"},
+    {file = "ruamel.yaml.clib-0.2.7-cp36-cp36m-win_amd64.whl", hash = "sha256:f34019dced51047d6f70cb9383b2ae2853b7fc4dce65129a5acd49f4f9256646"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2aa261c29a5545adfef9296b7e33941f46aa5bbd21164228e833412af4c9c75f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f01da5790e95815eb5a8a138508c01c758e5f5bc0ce4286c4f7028b8dd7ac3d0"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:40d030e2329ce5286d6b231b8726959ebbe0404c92f0a578c0e2482182e38282"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c3ca1fbba4ae962521e5eb66d72998b51f0f4d0f608d3c0347a48e1af262efa7"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win32.whl", hash = "sha256:7bdb4c06b063f6fd55e472e201317a3bb6cdeeee5d5a38512ea5c01e1acbdd93"},
+    {file = "ruamel.yaml.clib-0.2.7-cp37-cp37m-win_amd64.whl", hash = "sha256:be2a7ad8fd8f7442b24323d24ba0b56c51219513cfa45b9ada3b87b76c374d4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91a789b4aa0097b78c93e3dc4b40040ba55bef518f84a40d4442f713b4094acb"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:99e77daab5d13a48a4054803d052ff40780278240a902b880dd37a51ba01a307"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3243f48ecd450eddadc2d11b5feb08aca941b5cd98c9b1db14b2fd128be8c697"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8831a2cedcd0f0927f788c5bdf6567d9dc9cc235646a434986a852af1cb54b4b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win32.whl", hash = "sha256:3110a99e0f94a4a3470ff67fc20d3f96c25b13d24c6980ff841e82bafe827cac"},
+    {file = "ruamel.yaml.clib-0.2.7-cp38-cp38-win_amd64.whl", hash = "sha256:92460ce908546ab69770b2e576e4f99fbb4ce6ab4b245345a3869a0a0410488f"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5bc0667c1eb8f83a3752b71b9c4ba55ef7c7058ae57022dd9b29065186a113d9"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:4a4d8d417868d68b979076a9be6a38c676eca060785abaa6709c7b31593c35d1"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf9a6bc4a0221538b1a7de3ed7bca4c93c02346853f44e1cd764be0023cd3640"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a7b301ff08055d73223058b5c46c55638917f04d21577c95e00e0c4d79201a6b"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win32.whl", hash = "sha256:d5e51e2901ec2366b79f16c2299a03e74ba4531ddcfacc1416639c557aef0ad8"},
+    {file = "ruamel.yaml.clib-0.2.7-cp39-cp39-win_amd64.whl", hash = "sha256:184faeaec61dbaa3cace407cffc5819f7b977e75360e8d5ca19461cd851a5fc5"},
+    {file = "ruamel.yaml.clib-0.2.7.tar.gz", hash = "sha256:1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"},
+]
 
 [[package]]
 name = "s3transfer"

--- a/data-products/poetry.lock
+++ b/data-products/poetry.lock
@@ -420,7 +420,7 @@ files = [
 
 [[package]]
 name = "common-utils"
-version = "0.3.2"
+version = "0.3.4"
 description = "Shared modules for prefect flow development and deployment"
 category = "main"
 optional = false

--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.4.2"
+version = "0.4.3"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -49,5 +49,5 @@ env = [
     'DF_CONFIG_SNOWFLAKE_WAREHOUSE=prefect_wh_test',
     'R:DF_CONFIG_GCP_CREDENTIALS={"service_account_file": "tests/test.json"}',
     'R:DF_CONFIG_SNOWFLAKE_GCP_STAGES={"default_name": "DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_DEV","default_location": "gs://test", "gcs_pocket_shared_name": "DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_SHARED","gcs_pocket_shared_location": "gs://test"}',
-    'DF_CONFIG_SQL_TEMPLATE_PATH=tests/sql_etl/unit/sql'
+    'D:DF_CONFIG_SQL_TEMPLATE_PATH=tests/sql_etl/unit/sql' # only sets if not already set https://github.com/pytest-dev/pytest-env#only-set-if-not-already-set
 ]

--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -48,5 +48,6 @@ env = [
     'DF_CONFIG_SNOWFLAKE_SCHEMA=test',
     'DF_CONFIG_SNOWFLAKE_WAREHOUSE=prefect_wh_test',
     'R:DF_CONFIG_GCP_CREDENTIALS={"service_account_file": "tests/test.json"}',
-    'R:DF_CONFIG_SNOWFLAKE_GCP_STAGES={"default_name": "DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_DEV","default_location": "gs://test", "gcs_pocket_shared_name": "DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_SHARED","gcs_pocket_shared_location": "gs://test"}'
+    'R:DF_CONFIG_SNOWFLAKE_GCP_STAGES={"default_name": "DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_DEV","default_location": "gs://test", "gcs_pocket_shared_name": "DEVELOPMENT.TEST.PREFECT_GCS_STAGE_PARQ_SHARED","gcs_pocket_shared_location": "gs://test"}',
+    'DF_CONFIG_SQL_TEMPLATE_PATH=tests/sql_etl/unit/sql'
 ]

--- a/data-products/src/shared/utils.py
+++ b/data-products/src/shared/utils.py
@@ -106,7 +106,7 @@ class SqlJob(BaseModel):
     )
     sql_template_path: str = Field(
         description="Override value for default from envar.",
-        default=SharedUtilsSettings().sql_template_path, # type: ignore
+        default=SharedUtilsSettings().sql_template_path,  # type: ignore
     )
     initial_last_offset: Optional[str] = Field(
         description="Optional initial batch start offset.",

--- a/data-products/src/shared/utils.py
+++ b/data-products/src/shared/utils.py
@@ -1,4 +1,3 @@
-import os
 from copy import deepcopy
 from pathlib import Path
 from typing import Optional, Union
@@ -17,7 +16,7 @@ from pydantic import BaseModel, Field
 class SharedUtilsSettings(Settings):
     """Setting model to define reusable settings."""
 
-    sql_template_path: Path
+    sql_template_path: Optional[str]
 
 
 class IntervalSet(BaseModel):
@@ -105,8 +104,9 @@ class SqlJob(BaseModel):
     sql_folder_name: str = Field(
         description="Relative folder name containing sql.",
     )
-    sql_template_path: Optional[str] = Field(
+    sql_template_path: str = Field(
         description="Override value for default from envar.",
+        default=SharedUtilsSettings().sql_template_path, # type: ignore
     )
     initial_last_offset: Optional[str] = Field(
         description="Optional initial batch start offset.",
@@ -131,15 +131,6 @@ class SqlJob(BaseModel):
             "to pass into your templates."
         ),
     )
-
-    @property
-    def sql_template_path_value(self) -> Path:
-        """Helper for getting template path from settings or override.
-
-        Returns:
-            Path: sql template path for object
-        """
-        return self.sql_template_path or SharedUtilsSettings().sql_template_path  # type: ignore  # noqa: E501
 
     @property
     def job_kwargs(self) -> dict:
@@ -187,7 +178,7 @@ class SqlJob(BaseModel):
         Returns:
             str: Rendered sql text.
         """
-        template_path = self.sql_template_path_value
+        template_path = self.sql_template_path
         render_kwargs = deepcopy(self.job_kwargs)
         render_kwargs.update(extra_kwargs)
         environment = Environment(

--- a/data-products/src/sql_etl/sql/backend_events_for_mozilla/data.sql
+++ b/data-products/src/sql_etl/sql/backend_events_for_mozilla/data.sql
@@ -6,6 +6,7 @@ collector_tstamp as submission_timestamp,
 derived_tstamp as event_timestamp,
 app_id as app_id,
 object_construct(
+  'metadata', object_construct(
     'geo', object_construct(
       'city', geo_city, 
       'country', geo_country),
@@ -13,15 +14,18 @@ object_construct(
       'browser', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:useragentFamily::string, 
       'os', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osFamily::string,
       'version', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:useragentMajor::string || CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:useragentMinor::string)
-    ) as metadata,
+    )
+) as metadata,
 object_construct(
+  'client_info', object_construct(
     'app_build', nvl(CONTEXTS_COM_SNOWPLOWANALYTICS_MOBILE_APPLICATION_1[0]:version::string, CONTEXTS_COM_POCKET_API_USER_1[0]:client_version::string),
     'client_id', CONTEXTS_COM_POCKET_USER_1[0]:hashed_guid::string,
     'user_id', CONTEXTS_COM_POCKET_USER_1[0]:hashed_user_id::string,
     'locale', br_lang,
     'os', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osFamily::string,
     'os_version', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osMajor::string || CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osMinor::string
-    ) as client_info,
+    )
+) as client_info,
 'event' as event_category,
 event_name,
 object_construct(

--- a/data-products/src/sql_etl/sql/backend_events_for_mozilla/data.sql
+++ b/data-products/src/sql_etl/sql/backend_events_for_mozilla/data.sql
@@ -6,7 +6,6 @@ collector_tstamp as submission_timestamp,
 derived_tstamp as event_timestamp,
 app_id as app_id,
 object_construct(
-  'metadata', object_construct(
     'geo', object_construct(
       'city', geo_city, 
       'country', geo_country),
@@ -14,18 +13,15 @@ object_construct(
       'browser', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:useragentFamily::string, 
       'os', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osFamily::string,
       'version', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:useragentMajor::string || CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:useragentMinor::string)
-    )
-) as metadata,
+    ) as metadata,
 object_construct(
-  'client_info', object_construct(
     'app_build', nvl(CONTEXTS_COM_SNOWPLOWANALYTICS_MOBILE_APPLICATION_1[0]:version::string, CONTEXTS_COM_POCKET_API_USER_1[0]:client_version::string),
     'client_id', CONTEXTS_COM_POCKET_USER_1[0]:hashed_guid::string,
     'user_id', CONTEXTS_COM_POCKET_USER_1[0]:hashed_user_id::string,
     'locale', br_lang,
     'os', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osFamily::string,
     'os_version', CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osMajor::string || CONTEXTS_COM_SNOWPLOWANALYTICS_SNOWPLOW_UA_PARSER_CONTEXT_1[0]:osMinor::string
-    )
-) as client_info,
+    ) as client_info,
 'event' as event_category,
 event_name,
 object_construct(

--- a/data-products/tests/sql_etl/unit/test_run_jobs_flow.py
+++ b/data-products/tests/sql_etl/unit/test_run_jobs_flow.py
@@ -19,8 +19,7 @@ def test_sql_job():
         kwargs={"destination_table_name": "test.test.test"},
         with_external_state=True,
         source_system="snowflake",
-        snowflake_stage_id=SF_GCP_STAGE_ID,
-        sql_template_path="tests/sql_etl/unit/sql",  # type: ignore
+        snowflake_stage_id=SF_GCP_STAGE_ID
     )
     intervals = t.get_intervals()
     assert [x.dict() for x in intervals] == [
@@ -82,7 +81,6 @@ def test_sql_job_external_state_biqquery():
         },
         source_system="bigquery",
         snowflake_stage_id=SF_GCP_STAGE_ID,  # type: ignore
-        sql_template_path="tests/sql_etl/unit/sql",  # type: ignore
     )
     intervals = t.get_intervals()
     assert [x.dict() for x in intervals] == [
@@ -143,7 +141,6 @@ async def test_interval():
         with_external_state=True,
         source_system="snowflake",
         snowflake_stage_id=SF_GCP_STAGE_ID,  # type: ignore
-        sql_template_path="tests/sql_etl/unit/sql",  # type: ignore
     )
     intervals = t.get_intervals()
     interval_input = intervals[0]
@@ -181,7 +178,6 @@ async def test_interval_bq_no_load_no_external_state():
         kwargs={"destination_table_name": "test.test.test"},
         source_system="bigquery",
         snowflake_stage_id=SF_GCP_STAGE_ID,  # type: ignore
-        sql_template_path="tests/sql_etl/unit/sql",  # type: ignore
     )
     intervals = t.get_intervals()
     interval_input = intervals[0]
@@ -221,7 +217,6 @@ async def test_interval_none_offset():
         with_external_state=True,
         source_system="bigquery",
         snowflake_stage_id=SF_GCP_STAGE_ID,  # type: ignore
-        sql_template_path="tests/sql_etl/unit/sql",  # type: ignore
     )
     intervals = t.get_intervals()
     interval_input = intervals[0]

--- a/data-products/tests/sql_etl/unit/test_run_jobs_flow.py
+++ b/data-products/tests/sql_etl/unit/test_run_jobs_flow.py
@@ -19,7 +19,7 @@ def test_sql_job():
         kwargs={"destination_table_name": "test.test.test"},
         with_external_state=True,
         source_system="snowflake",
-        snowflake_stage_id=SF_GCP_STAGE_ID
+        snowflake_stage_id=SF_GCP_STAGE_ID,
     )
     intervals = t.get_intervals()
     assert [x.dict() for x in intervals] == [


### PR DESCRIPTION
## Goal
Fixing bugs related to schedules and sql template paths

- Fixed the `IntervalSchedule` creation to use proper function for converting non seconds units into seconds
- Remove the way I was setting the sql template path in `sql_etl` in favor a simpler approach that supports both envars or a dynamic default path specific to `sql_etl`
- added functionality to have global flow envars via `deployment` module...thought I needed it for the above fixes, but didn't...keeping since it was easy to add and still valuable
- lots of unit test changes to support the work above
- ~~removed some extra nesting from 2 columns in the `backend_events_for_mozilla` sql~~.  Talked with Jan-Erik and they are already accounting for the extra nesting in the `backend_events_for_mozilla` sql....so leaving it.

## Test Results

Issue with schedules shown as fixed.  Deployed a main deployment to my local to test that daily schedule for `backend_events_for_mozilla` was being set properly.

<img width="1455" alt="image" src="https://github.com/Pocket/data-flows/assets/11067272/a27254f8-4cd3-4add-89a2-3ea4d0d196ab">


The issue with the sql template path was that scheduled runs and manual run to were setting different paths....this seems to be due to how I was setting it before.     Here are the test results in staging after fix:


 

## Deployment steps
None....automated


## References

JIRA ticket:
[DIS-831](https://getpocket.atlassian.net/browse/DIS-831)

