### PR TITLE
 fix(data-products): fix kwargs.destination_table_name and sql_folder_name values for sql_etl.impression_stats_v1

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.4.3"
+version = "0.4.4"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -425,9 +425,9 @@ FLOW_SPEC = FlowSpec(
             ),
             parameters={
                 "etl_input": SqlEtlJob(
-                    sql_folder_name="impression_stats_v1_new",
+                    sql_folder_name="impression_stats_v1",
                     initial_last_offset="2022-12-23",
-                    kwargs={"destination_table_name": "impression_stats_v1"},
+                    kwargs={"destination_table_name": "impression_stats_v1_new"},
                     source_system="bigquery",
                 ).dict()  # type: ignore
             },


### PR DESCRIPTION
For the `impression_stats_v1` deployment on `sql_etl`, I updated the wrong parameter.

Should be kwargs={"destination_table_name": "impression_stats_v1_new"}` not sql_folder_name="impression_stats_v1_new".

https://getpocket.atlassian.net/browse/DIS-832