### PR TITLE
fix: covid candidate set is can be empty

### DIFF
--- a/src/common_tasks/corpus_candidate_set.py
+++ b/src/common_tasks/corpus_candidate_set.py
@@ -12,8 +12,7 @@ from utils import config
 
 
 @task()
-def validate_corpus_items(corpus_items: List[Dict]):
-    min_item_count = 1
+def validate_corpus_items(corpus_items: List[Dict], min_item_count: int = 1):
     expected_keys = ['ID', 'TOPIC', 'PUBLISHER']
 
     assert len(corpus_items) >= min_item_count

--- a/src/flows/recommendation_api/corpus_candidate_sets/corpus_candidate_sets.py
+++ b/src/flows/recommendation_api/corpus_candidate_sets/corpus_candidate_sets.py
@@ -87,7 +87,10 @@ def query_corpus_candidate_set(candidate_set_config: CorpusCandidateSetConfig) -
         schema=config.SNOWFLAKE_ANALYTICS_DBT_SCHEMA,
     )
 
-    validate_corpus_items.run(corpus_items)
+    validate_corpus_items.run(
+        corpus_items,
+        min_item_count=0 if 'coronavirus' in candidate_set_config.name else 1
+    )
 
     return create_corpus_candidate_set_record.run(
         id=candidate_set_config.id,


### PR DESCRIPTION
## Goal
The `corpus_candidate_sets` Prefect flow keeps failing because there are no coronavirus curated items in the last 90 days.

## QA
- [x] Flow successfully runs locally

## Implementation Decisions
Disable non-empty validation step for coronavirus.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-25

Prefect error:
* https://cloud.prefect.io/pocket/task-run/127bcb2a-87f1-488a-bee0-2544a2cb6eb1?logs&schematic=9e70bec6-28ef-49e7-921a-85928881fc13
