### PR TITLE
fix(sql-etl): monthly logic for new tab extraction was not correct...need to add a different key for merging

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.6.0"
+version = "0.6.1"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/shared/async_utils.py
+++ b/data-products/src/shared/async_utils.py
@@ -13,4 +13,4 @@ async def process_parallel_subflows(
 
     group = [with_concurrency_limit(coroutine) for coroutine in coroutines]
 
-    await asyncio.gather(*group)
+    await asyncio.gather(*group, return_exceptions=True)

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -536,5 +536,5 @@ if __name__ == "__main__":
 
     t = SqlEtlJob(sql_folder_name="firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed"
                   ,kwargs={"for_backfill": True},
-                  override_last_offset="2023-08-01 23:59:59.999")  # type: ignore
+                  override_last_offset="2023-08-01 23:59:59.999999")  # type: ignore
     run(main(etl_input=t))  # type: ignore

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -534,7 +534,9 @@ FLOW_SPEC = FlowSpec(
 if __name__ == "__main__":
     from asyncio import run
 
-    t = SqlEtlJob(sql_folder_name="firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed"
-                  ,kwargs={"for_backfill": True},
-                  override_last_offset="2023-08-01 23:59:59.999999")  # type: ignore
+    t = SqlEtlJob(
+        sql_folder_name="firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed",
+        kwargs={"for_backfill": True},
+        override_last_offset="2023-08-01 23:59:59.999999",
+    )  # type: ignore
     run(main(etl_input=t))  # type: ignore

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -534,5 +534,7 @@ FLOW_SPEC = FlowSpec(
 if __name__ == "__main__":
     from asyncio import run
 
-    t = SqlEtlJob(sql_folder_name="firefox_new_tab_impressions_hourly")  # type: ignore
+    t = SqlEtlJob(sql_folder_name="firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed"
+                  ,kwargs={"for_backfill": True},
+                  override_last_offset="2023-08-01 23:59:59.999")  # type: ignore
     run(main(etl_input=t))  # type: ignore

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
@@ -16,7 +16,7 @@ WITH
     {% else %}
       `moz-fx-data-shared-prod.activity_stream_live.impression_stats_v1`  
     {% endif %}
-    WHERE submission_timestamp >= CAST(DATE_SUB(CAST({{ helpers.parse_iso8601(batch_end) }} as DATE), INTERVAL 1 MONTH) as TIMESTAMP)
+    WHERE submission_timestamp >= CAST(DATE_SUB(CAST({{ helpers.parse_iso8601(batch_start) }} as DATE), INTERVAL 1 MONTH) as TIMESTAMP)
     AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
     QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
     document_id

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
@@ -16,7 +16,7 @@ WITH
     {% else %}
       `moz-fx-data-shared-prod.activity_stream_live.impression_stats_v1`  
     {% endif %}
-    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    WHERE submission_timestamp >= CAST(DATE_SUB(CAST({{ helpers.parse_iso8601(batch_end) }} as DATE), INTERVAL 1 MONTH) as TIMESTAMP)
     AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
     QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
     document_id
@@ -151,6 +151,7 @@ SELECT
       WHEN a.clicks > 0 AND a.user_prefs & 4 = 4 AND a.user_prefs & 32 = 32 AND t.type = 'spoc' THEN a.client_id
   END
     ) AS users_clicking_spocs_count,
+  CAST({{ helpers.parse_iso8601(batch_start) }} as DATE) as aggregation_date
 FROM
   flattened_impression_data AS a
 LEFT JOIN

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/load.sql
@@ -9,7 +9,8 @@
     users_clicking_recs_count number not null,
     users_eligible_for_spocs_count number not null,
     users_viewing_spocs_count number not null,
-    users_clicking_spocs_count number not null 
+    users_clicking_spocs_count number not null,
+    aggregation_date date not null
 {% endmacro %}
 
-{{ helpers.sf_merge(table_def(), 'happened_at') }}
+{{ helpers.sf_merge(table_def(), 'aggregation_date') }}


### PR DESCRIPTION

## Goal
What changed? What is the business/product goal?

- set `return_exceptions = True` for `async.gather` in `async_utils` module so that on failed coroutine does not cause the others to crash.  They should all finish before returning the exception from the bad one.
- update the logic on the monthly extract to do a proper months worth of data from the interval date.  I then add the interval date to the table so that we can properly merge.  The previous way was constantly rewriting only ever leaving a single row of data for that month.  We want a month of data everyday as a distinct row in the table.

Testing shows that the number of rows do match the older extraction when grouping the newer data (which has added feed as a column) by `happened_at` and `aggregation_date`.  The test replicates a flow run that would have run on 08/03/2023:

```sql
select count(distinct aggregation_date, happened_at)
from development.braun.firefox_new_tab_monthly_unique_engagement_by_feed
union all
select count(*) from airflow.mozilla.mozilla_activity_stream_monthly_uniques
where snowflake_loaded_at >= '2023-08-03';
```
<img width="477" alt="image" src="https://github.com/Pocket/data-flows/assets/11067272/4f9ce046-fd7e-4adb-84dc-ef50c931db5f">

Here are the unique happened_at and aggregation_date rows for backfill of data starting on 8/2:

<img width="389" alt="image" src="https://github.com/Pocket/data-flows/assets/11067272/2d5cbbfa-97db-4560-bb47-64e5bdc9596e">

Here is a sample extraction statement:

```sql
        EXPORT DATA OPTIONS(
          uri='gs://dev-bucket/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/date=2023-08-02/time=00-00-00-000/data*.parq',
          format='PARQUET',
          compression='SNAPPY',
          overwrite=true) AS
        



WITH
  deduplicated AS (
    SELECT
      *   
    FROM
      
      `moz-fx-data-shared-prod.activity_stream_stable.impression_stats_v1`
    
    WHERE submission_timestamp >= CAST(DATE_SUB(CAST(
    PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*SZ', '2023-08-02T00:00:00Z')
 as DATE), INTERVAL 1 MONTH) as TIMESTAMP)
    AND submission_timestamp < 
    PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*SZ', '2023-08-03T00:00:00Z')

    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
    document_id
    ORDER BY
    submission_timestamp desc) = 1
),
  impression_data AS (
  SELECT
    *,
    CASE
      WHEN ( normalized_country_code IN ('US', 'CA') AND locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
      WHEN ( normalized_country_code IN ('GB',
        'IE')
      AND locale IN ('en-CA',
        'en-GB',
        'en-US') ) THEN 'NEW_TAB_EN_GB'
      WHEN ( normalized_country_code IN ('IN') AND locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
      WHEN ( normalized_country_code IN ('DE',
        'CH',
        'AT',
        'BE')
      AND locale IN ('de',
        'de-AT',
        'de-CH') ) THEN 'NEW_TAB_DE_DE'
      WHEN (normalized_country_code IN ('IT') AND locale IN ('it')) THEN 'NEW_TAB_IT_IT'
      WHEN (normalized_country_code IN ('FR')
      AND locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
      WHEN (normalized_country_code IN ('ES') AND locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
  END
    AS feed_name
  FROM
    deduplicated
  WHERE
    loaded IS NULL --don't include loaded ping
    AND ARRAY_LENGTH(tiles) >= 1 --make sure data is valid/non-empty
    AND release_channel = 'release'
    AND ( ( normalized_country_code IN ('US',
          'CA',
          'GB',
          'IE',
          'IN')
        AND locale IN ('en-CA',
          'en-GB',
          'en-US') )
      OR ( normalized_country_code IN ('DE',
          'CH',
          'AT',
          'BE')
        AND locale IN ('de',
          'de-AT',
          'de-CH') )
      OR (normalized_country_code IN ('IT')
        AND locale IN ('it'))
      OR (normalized_country_code IN ('FR')
        AND locale IN ('fr'))
      OR (normalized_country_code IN ('ES')
        AND locale IN ('es-ES')) ) ),
  flattened_impression_data AS ( --need this step to filter out >2 clicks from a given client on the same tile within 1 second
  SELECT
    UNIX_SECONDS(submission_timestamp) AS submission_timestamp,
    feed_name,
    --truncate timestamp to seconds
    impression_id AS client_id,
    --client_id renamed to impression_id in GCP
    user_prefs,
    flattened_tiles.id AS tile_id,
    IFNULL(flattened_tiles.pos, alt_pos) AS position,
    --the 3x1 layout has a bug where we need to use the position of each element in the tiles array instead of the actual pos field
    SUM(CASE
        WHEN click IS NULL AND block IS NULL AND pocket IS NULL THEN 1
      ELSE
      0
    END
      ) AS impressions,
    SUM(CASE
        WHEN click IS NOT NULL THEN 1
      ELSE
      0
    END
      ) AS clicks,
    SUM(CASE
        WHEN pocket IS NOT NULL THEN 1
      ELSE
      0
    END
      ) AS pocketed,
    SUM(CASE
        WHEN block IS NOT NULL THEN 1
      ELSE
      0
    END
      ) AS blocked
  FROM
    impression_data
  CROSS JOIN
    UNNEST(impression_data.tiles) AS flattened_tiles
  WITH
  OFFSET
    AS alt_pos
  GROUP BY
    1,
    2,
    3,
    4,
    5,
    6 )
SELECT
  DATE_TRUNC(DATE(TIMESTAMP_SECONDS(a.submission_timestamp)), month) AS happened_at,
  feed_name,
  COUNT(DISTINCT
    CASE
      WHEN a.impressions > 0 THEN a.client_id
  END
    ) AS users_viewing_recs_count,
  COUNT(DISTINCT
    CASE
      WHEN a.clicks > 0 THEN a.client_id
  END
    ) AS users_clicking_recs_count,
  COUNT(DISTINCT
    CASE
      WHEN a.impressions > 0 AND a.user_prefs & 4 = 4 AND a.user_prefs & 32 = 32 THEN a.client_id
  END
    ) AS users_eligible_for_spocs_count,
  COUNT(DISTINCT
    CASE
      WHEN a.impressions > 0 AND a.user_prefs & 4 = 4 AND a.user_prefs & 32 = 32 AND t.type = 'spoc' THEN a.client_id
  END
    ) AS users_viewing_spocs_count,
  COUNT(DISTINCT
    CASE
      WHEN a.clicks > 0 AND a.user_prefs & 4 = 4 AND a.user_prefs & 32 = 32 AND t.type = 'spoc' THEN a.client_id
  END
    ) AS users_clicking_spocs_count,
  CAST(
    PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*SZ', '2023-08-02T00:00:00Z')
 as DATE) as aggregation_date
FROM
  flattened_impression_data AS a
LEFT JOIN
  `moz-fx-data-shared-prod.pocket.spoc_tile_ids` AS t
ON
  a.tile_id = t.tile_id
WHERE
  a.clicks < 3
GROUP BY
  1,
  2
ORDER BY
  1,
  2;
```

New merge logic:

```sql

set merge_key = (select min(aggregation_date) from firefox_new_tab_monthly_unique_engagement_by_feed_tmp);
delete from firefox_new_tab_monthly_unique_engagement_by_feed 
    where aggregation_date >= $merge_key;
insert into firefox_new_tab_monthly_unique_engagement_by_feed 
    select * from firefox_new_tab_monthly_unique_engagement_by_feed_tmp;
```

## References

JIRA ticket:
* [SOCIALPLAT-464](https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-464)