### PR TITLE
Changing new tab extraction sources

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.7.1"
+version = "0.8.0"
 
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -571,6 +571,6 @@ if __name__ == "__main__":
     t = SqlEtlJob(
         sql_folder_name="glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale",
         kwargs={"for_backfill": False},
-        #override_last_offset="2023-12-04 23:59:59.999999",
+        # override_last_offset="2023-12-04 23:59:59.999999",
     )  # type: ignore
     run(main(etl_input=t))  # type: ignore

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -527,6 +527,40 @@ FLOW_SPEC = FlowSpec(
                 ),
             ],
         ),
+        FlowDeployment(
+            deployment_name="glean_firefox_new_tab_impressions_daily",
+            schedule=CronSchedule(cron="0 6 * * *"),
+            parameters={
+                "etl_input": SqlEtlJob(
+                    sql_folder_name="glean_firefox_new_tab_impressions_daily"
+                ).dict()  # type: ignore
+            },
+            envars=[
+                FlowEnvar(
+                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
+                    envar_value=CS.deployment_type_value(
+                        dev="cbeck", staging="staging", main="mozilla"
+                    ),  # type: ignore
+                ),
+            ],
+        ),
+        FlowDeployment(
+            deployment_name="glean_firefox_new_tab_impressions_hourly",
+            schedule=CronSchedule(cron="0 * * * *"),
+            parameters={
+                "etl_input": SqlEtlJob(
+                    sql_folder_name="glean_firefox_new_tab_impressions_hourly"
+                ).dict()  # type: ignore
+            },
+            envars=[
+                FlowEnvar(
+                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
+                    envar_value=CS.deployment_type_value(
+                        dev="cbeck", staging="staging", main="mozilla"
+                    ),  # type: ignore
+                ),
+            ],
+        ),
     ],
 )
 
@@ -535,8 +569,8 @@ if __name__ == "__main__":
     from asyncio import run
 
     t = SqlEtlJob(
-        sql_folder_name="firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed",
-        kwargs={"for_backfill": True},
-        override_last_offset="2023-08-01 23:59:59.999999",
+        sql_folder_name="glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale",
+        kwargs={"for_backfill": False},
+        #override_last_offset="2023-12-04 23:59:59.999999",
     )  # type: ignore
     run(main(etl_input=t))  # type: ignore

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_disable_rate_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_disable_rate_by_feed/data.sql
@@ -63,6 +63,7 @@ FROM
   deduplicated
 WHERE
   release_channel = 'release'
+  AND SAFE_CAST(SPLIT(version, '.')[0] AS int64) <= 120 --include only data from Firefox < 121
   AND (version LIKE '1%'
     OR version LIKE '2%'
     OR version LIKE '3%'

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
@@ -49,6 +49,7 @@ WITH
     deduplicated AS s
   WHERE
     loaded IS NULL --don't include loaded ping
+    AND SAFE_CAST(SPLIT(version, '.')[0] AS int64) <= 120 --include only data from Firefox < 121
     AND ARRAY_LENGTH(tiles) >= 1 --make sure data is valid/non-empty
     AND click IS NULL
     AND block IS NULL

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_unique_engagement_by_feed/data.sql
@@ -48,6 +48,7 @@ WITH
     deduplicated AS s
   WHERE
     loaded IS NULL --don't include loaded ping
+    AND SAFE_CAST(SPLIT(version, '.')[0] AS int64) <= 120 --include only data from Firefox < 121
     AND ARRAY_LENGTH(tiles) >= 1 --make sure data is valid/non-empty
     AND release_channel = 'release'
     AND ( ( normalized_country_code IN ('US',

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
@@ -51,6 +51,7 @@ WITH
     deduplicated
   WHERE
     loaded IS NULL --don't include loaded ping
+    AND SAFE_CAST(SPLIT(version, '.')[0] AS int64) <= 120 --include only data from Firefox < 121
     AND ARRAY_LENGTH(tiles) >= 1 --make sure data is valid/non-empty
     AND release_channel = 'release'
     AND ( ( normalized_country_code IN ('US',

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly/firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly/firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -19,6 +19,7 @@ impression_data AS (
     deduplicated AS s
   WHERE
     loaded IS NULL --don't include loaded ping
+    AND SAFE_CAST(SPLIT(version, '.')[0] AS int64) <= 120 --include only data from Firefox < 121
     AND ARRAY_LENGTH(tiles) >= 1 --make sure data is valid/non-empty
     AND (page IS NULL
       OR page != 'https://newtab.firefoxchina.cn/newtab/as/activity-stream.html') --exclude custom New Tab page for FX China

--- a/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly/firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly/firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -19,6 +19,7 @@ impression_data AS (
     deduplicated AS s
   WHERE
     loaded IS NULL --don't include loaded ping
+    AND SAFE_CAST(SPLIT(version, '.')[0] AS int64) <= 120 --include only data from Firefox < 121
     AND ARRAY_LENGTH(tiles) >= 1 --make sure data is valid/non-empty
     AND (page IS NULL
       OR page != 'https://newtab.firefoxchina.cn/newtab/as/activity-stream.html') --exclude custom New Tab page for FX China

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/data.sql
@@ -9,17 +9,16 @@
 
 WITH
   deduplicated_pings AS (
-    SELECT
-      *   
-    FROM
-      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
-    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
-    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
-    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
-    document_id
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+  WHERE
+    submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
+      document_id
     ORDER BY
-    submission_timestamp desc) = 1
-)
+      submission_timestamp DESC) = 1 )
 SELECT
   DATE(submission_timestamp) AS happened_at,
   CASE
@@ -46,17 +45,17 @@ END
   COUNT(DISTINCT client_info.client_id) AS users_opening_new_tab_count,
   COUNT(DISTINCT
     CASE
-      WHEN metrics.boolean.pocket_enabled = False THEN client_info.client_id
+      WHEN metrics.boolean.pocket_enabled = FALSE THEN client_info.client_id
   END
     ) AS users_with_pocket_disabled_count,
   COUNT(DISTINCT
     CASE
-      WHEN metrics.boolean.pocket_sponsored_stories_enabled = False THEN client_info.client_id
+      WHEN metrics.boolean.pocket_sponsored_stories_enabled = FALSE THEN client_info.client_id
   END
     ) AS users_with_spocs_disabled_count,
   COUNT(DISTINCT
     CASE
-      WHEN metrics.boolean.pocket_enabled = True AND metrics.boolean.pocket_sponsored_stories_enabled = True THEN client_info.client_id
+      WHEN metrics.boolean.pocket_enabled = TRUE AND metrics.boolean.pocket_sponsored_stories_enabled = TRUE THEN client_info.client_id
   END
     ) AS users_eligible_for_spocs_count,
 FROM
@@ -66,28 +65,28 @@ WHERE
   normalized_channel = 'release'
   --include only data from Firefox 121+
   AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
-    --limit to locale & country combinations with Pocket enabled
-    AND ( ( normalized_country_code IN ('US',
-          'CA',
-          'GB',
-          'IE',
-          'IN')
-        AND metrics.string.newtab_locale IN ('en-CA',
-          'en-GB',
-          'en-US') )
-      OR ( normalized_country_code IN ('DE',
-          'CH',
-          'AT',
-          'BE')
-        AND metrics.string.newtab_locale IN ('de',
-          'de-AT',
-          'de-CH') )
-      OR (normalized_country_code IN ('IT')
-        AND metrics.string.newtab_locale IN ('it'))
-      OR (normalized_country_code IN ('FR')
-        AND metrics.string.newtab_locale IN ('fr'))
-      OR (normalized_country_code IN ('ES')
-        AND metrics.string.newtab_locale IN ('es-ES')) )
+  --limit to locale & country combinations with Pocket enabled
+  AND ( ( normalized_country_code IN ('US',
+        'CA',
+        'GB',
+        'IE',
+        'IN')
+      AND metrics.string.newtab_locale IN ('en-CA',
+        'en-GB',
+        'en-US') )
+    OR ( normalized_country_code IN ('DE',
+        'CH',
+        'AT',
+        'BE')
+      AND metrics.string.newtab_locale IN ('de',
+        'de-AT',
+        'de-CH') )
+    OR (normalized_country_code IN ('IT')
+      AND metrics.string.newtab_locale IN ('it'))
+    OR (normalized_country_code IN ('FR')
+      AND metrics.string.newtab_locale IN ('fr'))
+    OR (normalized_country_code IN ('ES')
+      AND metrics.string.newtab_locale IN ('es-ES')) )
 GROUP BY
   1,
   2

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/data.sql
@@ -1,0 +1,96 @@
+{% set sql_engine = "bigquery" %}
+{% import 'helpers.j2' as helpers with context %}
+{% if for_new_offset %}
+    select current_timestamp()
+{% else %}
+
+--replicates logic of current Prefect query using Glean data
+--https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_disable_rate_by_feed/data.sql
+
+WITH
+  deduplicated_pings AS (
+    SELECT
+      *   
+    FROM
+      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
+    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
+    document_id
+    ORDER BY
+    submission_timestamp desc) = 1
+)
+SELECT
+  DATE(submission_timestamp) AS happened_at,
+  CASE
+    WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+    WHEN ( normalized_country_code IN ('GB',
+      'IE')
+    AND metrics.string.newtab_locale IN ('en-CA',
+      'en-GB',
+      'en-US') ) THEN 'NEW_TAB_EN_GB'
+    WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+    WHEN ( normalized_country_code IN ('DE',
+      'CH',
+      'AT',
+      'BE')
+    AND metrics.string.newtab_locale IN ('de',
+      'de-AT',
+      'de-CH') ) THEN 'NEW_TAB_DE_DE'
+    WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+    WHEN (normalized_country_code IN ('FR')
+    AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+    WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+END
+  AS feed_name,
+  COUNT(DISTINCT client_info.client_id) AS users_opening_new_tab_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN metrics.boolean.pocket_enabled = False THEN client_info.client_id
+  END
+    ) AS users_with_pocket_disabled_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN metrics.boolean.pocket_sponsored_stories_enabled = False THEN client_info.client_id
+  END
+    ) AS users_with_spocs_disabled_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN metrics.boolean.pocket_enabled = True AND metrics.boolean.pocket_sponsored_stories_enabled = True THEN client_info.client_id
+  END
+    ) AS users_eligible_for_spocs_count,
+FROM
+  deduplicated_pings
+WHERE
+  --include only release channel data
+  normalized_channel = 'release'
+  --include only data from Firefox 121+
+  AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+    --limit to locale & country combinations with Pocket enabled
+    AND ( ( normalized_country_code IN ('US',
+          'CA',
+          'GB',
+          'IE',
+          'IN')
+        AND metrics.string.newtab_locale IN ('en-CA',
+          'en-GB',
+          'en-US') )
+      OR ( normalized_country_code IN ('DE',
+          'CH',
+          'AT',
+          'BE')
+        AND metrics.string.newtab_locale IN ('de',
+          'de-AT',
+          'de-CH') )
+      OR (normalized_country_code IN ('IT')
+        AND metrics.string.newtab_locale IN ('it'))
+      OR (normalized_country_code IN ('FR')
+        AND metrics.string.newtab_locale IN ('fr'))
+      OR (normalized_country_code IN ('ES')
+        AND metrics.string.newtab_locale IN ('es-ES')) )
+GROUP BY
+  1,
+  2
+ORDER BY
+  1
+{% endif %}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/load.sql
@@ -4,7 +4,7 @@
 
 {% macro table_def() %}
     happened_at date not null,
-    feed_name string,
+    feed_name string not null,
     users_opening_new_tab_count number not null,
     users_with_pocket_disabled_count number not null,
     users_with_spocs_disabled_count number not null,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/load.sql
@@ -1,0 +1,14 @@
+{% set sql_engine = "snowflake" %}
+{% set is_multi_statement = True %}
+{% import 'helpers.j2' as helpers with context %}
+
+{% macro table_def() %}
+    happened_at date not null,
+    feed_name string,
+    users_opening_new_tab_count number not null,
+    users_with_pocket_disabled_count number not null,
+    users_with_spocs_disabled_count number not null,
+    users_eligible_for_spocs_count number not null
+{% endmacro %}
+
+{{ helpers.sf_merge(table_def(), 'happened_at') }}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/offset.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_disable_rate_by_feed/offset.sql
@@ -1,0 +1,2 @@
+{% set sql_engine = "snowflake" %}
+select (trunc(sysdate()::timestamp, 'day') - interval '1 day') - interval '1 microsecond';

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
@@ -6,87 +6,96 @@
 
 --replicates logic of current Prefect query using Glean data
 --https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
+
 WITH
-
   deduplicated_pings AS (
-    SELECT
-      *   
-    FROM
-      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
-    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
-    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
-    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
-    document_id
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+  WHERE
+    submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
+      document_id
     ORDER BY
-    submission_timestamp desc) = 1
-),
-  flattened_impression_data as (
-    SELECT
-        DATE(submission_timestamp) as happened_at,
-        CASE
-            WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
-            WHEN ( normalized_country_code IN ('GB',
-              'IE')
-            AND metrics.string.newtab_locale IN ('en-CA',
-              'en-GB',
-              'en-US') ) THEN 'NEW_TAB_EN_GB'
-            WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
-            WHEN ( normalized_country_code IN ('DE',
-              'CH',
-              'AT',
-              'BE')
-            AND metrics.string.newtab_locale IN ('de',
-              'de-AT',
-              'de-CH') ) THEN 'NEW_TAB_DE_DE'
-            WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
-            WHEN (normalized_country_code IN ('FR')
-            AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
-            WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
-        END
-          AS feed_name,
-        SAFE_CAST(mozfun.map.get_key(e.extra, 'position') AS int64) as position,
-        SAFE_CAST(mozfun.map.get_key(e.extra, 'is_sponsored') AS boolean) as is_sponsored,
-        COUNT(1) as impressions
-    FROM deduplicated_pings, UNNEST(events) as e
+      submission_timestamp DESC) = 1 ),
+  flattened_impression_data AS (
+  SELECT
+    DATE(submission_timestamp) AS happened_at,
+    CASE
+      WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+      WHEN ( normalized_country_code IN ('GB',
+        'IE')
+      AND metrics.string.newtab_locale IN ('en-CA',
+        'en-GB',
+        'en-US') ) THEN 'NEW_TAB_EN_GB'
+      WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+      WHEN ( normalized_country_code IN ('DE',
+        'CH',
+        'AT',
+        'BE')
+      AND metrics.string.newtab_locale IN ('de',
+        'de-AT',
+        'de-CH') ) THEN 'NEW_TAB_DE_DE'
+      WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+      WHEN (normalized_country_code IN ('FR')
+      AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+      WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+  END
+    AS feed_name,
+    SAFE_CAST(mozfun.map.get_key(e.extra,
+        'position') AS int64) AS position,
+    SAFE_CAST(mozfun.map.get_key(e.extra,
+        'is_sponsored') AS boolean) AS is_sponsored,
+    COUNT(1) AS impressions
+  FROM
+    deduplicated_pings,
+    UNNEST(events) AS e
     --filter to Pocket events
-    WHERE e.category = 'pocket'
-        --limit to impressions
-        and e.name = 'impression'
-        --keep only data with a non-null recommendation ID or tile ID
-        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
-        --include only release channel data
-        and normalized_channel = 'release'
-        --include only data from Firefox 121+
-        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
-        --include only users with both Pocket and SPOCs enabled
-        and metrics.boolean.pocket_enabled = True
-        and metrics.boolean.pocket_sponsored_stories_enabled = True
-        --limit to locale & country combinations with Pocket enabled
-        AND ( ( normalized_country_code IN ('US',
-              'CA',
-              'GB',
-              'IE',
-              'IN')
-            AND metrics.string.newtab_locale IN ('en-CA',
-              'en-GB',
-              'en-US') )
-            OR ( normalized_country_code IN ('DE',
-              'CH',
-              'AT',
-              'BE')
-            AND metrics.string.newtab_locale IN ('de',
-              'de-AT',
-              'de-CH') )
-            OR (normalized_country_code IN ('IT')
-            AND metrics.string.newtab_locale IN ('it'))
-            OR (normalized_country_code IN ('FR')
-            AND metrics.string.newtab_locale IN ('fr'))
-            OR (normalized_country_code IN ('ES')
-            AND metrics.string.newtab_locale IN ('es-ES')) )
-    group by 1, 2, 3, 4
-),
-
-new_tab_impressions AS ( --use impressions of first position as a proxy for # of new tab opens
+  WHERE
+    e.category = 'pocket'
+    --limit to impressions
+    AND e.name = 'impression'
+    --keep only data with a non-null recommendation ID or tile ID
+    AND (mozfun.map.get_key(e.extra,
+        'recommendation_id') IS NOT NULL
+      OR mozfun.map.get_key(e.extra,
+        'tile_id') IS NOT NULL)
+    --include only release channel data
+    AND normalized_channel = 'release'
+    --include only data from Firefox 121+
+    AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+    --include only users with both Pocket and SPOCs enabled
+    AND metrics.boolean.pocket_enabled = TRUE
+    AND metrics.boolean.pocket_sponsored_stories_enabled = TRUE
+    --limit to locale & country combinations with Pocket enabled
+    AND ( ( normalized_country_code IN ('US',
+          'CA',
+          'GB',
+          'IE',
+          'IN')
+        AND metrics.string.newtab_locale IN ('en-CA',
+          'en-GB',
+          'en-US') )
+      OR ( normalized_country_code IN ('DE',
+          'CH',
+          'AT',
+          'BE')
+        AND metrics.string.newtab_locale IN ('de',
+          'de-AT',
+          'de-CH') )
+      OR (normalized_country_code IN ('IT')
+        AND metrics.string.newtab_locale IN ('it'))
+      OR (normalized_country_code IN ('FR')
+        AND metrics.string.newtab_locale IN ('fr'))
+      OR (normalized_country_code IN ('ES')
+        AND metrics.string.newtab_locale IN ('es-ES')) )
+  GROUP BY
+    1,
+    2,
+    3,
+    4 ),
+  new_tab_impressions AS ( --use impressions of first position as a proxy for # of new tab opens
   SELECT
     happened_at,
     feed_name,
@@ -96,9 +105,9 @@ new_tab_impressions AS ( --use impressions of first position as a proxy for # of
   WHERE
     position = 0
   GROUP BY
-    1, 2),
-    
-impression_counts AS (
+    1,
+    2),
+  impression_counts AS (
   SELECT
     a.happened_at,
     a.feed_name,
@@ -106,7 +115,7 @@ impression_counts AS (
     MIN(n.new_tab_impressions) AS new_tab_impression_count,
     SUM(a.impressions) AS position_total_impression_count,
     SUM(CASE
-        WHEN a.is_sponsored = True THEN a.impressions
+        WHEN a.is_sponsored = TRUE THEN a.impressions
     END
       ) AS position_spoc_impression_count,
   FROM
@@ -115,7 +124,7 @@ impression_counts AS (
     new_tab_impressions AS n
   ON
     n.happened_at = a.happened_at
-        and n.feed_name = a.feed_name
+    AND n.feed_name = a.feed_name
   WHERE
     a.position IN (2,
       4,
@@ -135,7 +144,6 @@ impression_counts AS (
     1,
     2,
     3)
-
 SELECT
   happened_at,
   feed_name,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
@@ -1,0 +1,152 @@
+{% set sql_engine = "bigquery" %}
+{% import 'helpers.j2' as helpers with context %}
+{% if for_new_offset %}
+    select current_timestamp()
+{% else %}
+
+--replicates logic of current Prefect query using Glean data
+--https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_spoc_fill_rate_by_position_feed/data.sql
+WITH
+
+  deduplicated_pings AS (
+    SELECT
+      *   
+    FROM
+      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
+    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
+    document_id
+    ORDER BY
+    submission_timestamp desc) = 1
+),
+  flattened_impression_data as (
+    SELECT
+        DATE(submission_timestamp) as happened_at,
+        CASE
+            WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+            WHEN ( normalized_country_code IN ('GB',
+              'IE')
+            AND metrics.string.newtab_locale IN ('en-CA',
+              'en-GB',
+              'en-US') ) THEN 'NEW_TAB_EN_GB'
+            WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+            WHEN ( normalized_country_code IN ('DE',
+              'CH',
+              'AT',
+              'BE')
+            AND metrics.string.newtab_locale IN ('de',
+              'de-AT',
+              'de-CH') ) THEN 'NEW_TAB_DE_DE'
+            WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+            WHEN (normalized_country_code IN ('FR')
+            AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+            WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+        END
+          AS feed_name,
+        SAFE_CAST(mozfun.map.get_key(e.extra, 'position') AS int64) as position,
+        SAFE_CAST(mozfun.map.get_key(e.extra, 'is_sponsored') AS boolean) as is_sponsored,
+        COUNT(1) as impressions
+    FROM deduplicated_pings, UNNEST(events) as e
+    --filter to Pocket events
+    WHERE e.category = 'pocket'
+        --limit to impressions
+        and e.name = 'impression'
+        --keep only data with a non-null recommendation ID or tile ID
+        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
+        --include only release channel data
+        and normalized_channel = 'release'
+        --include only data from Firefox 121+
+        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+        --include only users with both Pocket and SPOCs enabled
+        and metrics.boolean.pocket_enabled = True
+        and metrics.boolean.pocket_sponsored_stories_enabled = True
+        --limit to locale & country combinations with Pocket enabled
+        AND ( ( normalized_country_code IN ('US',
+              'CA',
+              'GB',
+              'IE',
+              'IN')
+            AND metrics.string.newtab_locale IN ('en-CA',
+              'en-GB',
+              'en-US') )
+            OR ( normalized_country_code IN ('DE',
+              'CH',
+              'AT',
+              'BE')
+            AND metrics.string.newtab_locale IN ('de',
+              'de-AT',
+              'de-CH') )
+            OR (normalized_country_code IN ('IT')
+            AND metrics.string.newtab_locale IN ('it'))
+            OR (normalized_country_code IN ('FR')
+            AND metrics.string.newtab_locale IN ('fr'))
+            OR (normalized_country_code IN ('ES')
+            AND metrics.string.newtab_locale IN ('es-ES')) )
+    group by 1, 2, 3, 4
+),
+
+new_tab_impressions AS ( --use impressions of first position as a proxy for # of new tab opens
+  SELECT
+    happened_at,
+    feed_name,
+    SUM(impressions) AS new_tab_impressions
+  FROM
+    flattened_impression_data
+  WHERE
+    position = 0
+  GROUP BY
+    1, 2),
+    
+impression_counts AS (
+  SELECT
+    a.happened_at,
+    a.feed_name,
+    a.position,
+    MIN(n.new_tab_impressions) AS new_tab_impression_count,
+    SUM(a.impressions) AS position_total_impression_count,
+    SUM(CASE
+        WHEN a.is_sponsored = True THEN a.impressions
+    END
+      ) AS position_spoc_impression_count,
+  FROM
+    flattened_impression_data AS a
+  JOIN
+    new_tab_impressions AS n
+  ON
+    n.happened_at = a.happened_at
+        and n.feed_name = a.feed_name
+  WHERE
+    a.position IN (2,
+      4,
+      11,
+      20)
+    OR a.position IN (1,
+      5,
+      7,
+      11,
+      18,
+      20)
+  GROUP BY
+    1,
+    2,
+    3
+  ORDER BY
+    1,
+    2,
+    3)
+
+SELECT
+  happened_at,
+  feed_name,
+  position,
+  new_tab_impression_count,
+  position_total_impression_count,
+  IFNULL(position_spoc_impression_count, 0) AS position_spoc_impression_count,
+FROM
+  impression_counts
+ORDER BY
+  1,
+  2,
+  3
+{% endif %}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/load.sql
@@ -4,7 +4,7 @@
 
 {% macro table_def() %}
     happened_at date not null,
-    feed_name string,
+    feed_name string not null,
     position number not null,
     new_tab_impression_count number not null,
     position_total_impression_count number not null,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/load.sql
@@ -1,0 +1,14 @@
+{% set sql_engine = "snowflake" %}
+{% set is_multi_statement = True %}
+{% import 'helpers.j2' as helpers with context %}
+
+{% macro table_def() %}
+    happened_at date not null,
+    feed_name string,
+    position number not null,
+    new_tab_impression_count number not null,
+    position_total_impression_count number not null,
+    position_spoc_impression_count number not null
+{% endmacro %}
+
+{{ helpers.sf_merge(table_def(), 'happened_at') }}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/offset.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_spoc_fill_rate_by_position_feed/offset.sql
@@ -1,0 +1,3 @@
+{% set sql_engine = "snowflake" %}
+select
+    (trunc(sysdate()::timestamp, 'day') - interval '1 day') - interval '1 microsecond';

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
@@ -89,9 +89,6 @@ WITH
         AND metrics.string.newtab_locale IN ('fr'))
       OR (normalized_country_code IN ('ES')
         AND metrics.string.newtab_locale IN ('es-ES')) ) )
-  --let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
-  --the duplicate clicks issue we saw with the legacy PingCentre events:
-  --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
 SELECT
   happened_at,
   feed_name,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
@@ -1,0 +1,127 @@
+{% set sql_engine = "bigquery" %}
+{% import 'helpers.j2' as helpers with context %}
+{% if for_new_offset %}
+    select current_timestamp()
+{% else %}
+
+--replicates logic of current Prefect query using Glean data
+--https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_daily_unique_engagement_by_feed/data.sql
+
+WITH
+  deduplicated_pings AS (
+    SELECT
+      *   
+    FROM
+      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
+    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
+    document_id
+    ORDER BY
+    submission_timestamp desc) = 1
+),
+  flattened_pocket_events as (
+    SELECT
+        DATE(submission_timestamp) as happened_at,
+        CASE
+            WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+            WHEN ( normalized_country_code IN ('GB',
+              'IE')
+            AND metrics.string.newtab_locale IN ('en-CA',
+              'en-GB',
+              'en-US') ) THEN 'NEW_TAB_EN_GB'
+            WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+            WHEN ( normalized_country_code IN ('DE',
+              'CH',
+              'AT',
+              'BE')
+            AND metrics.string.newtab_locale IN ('de',
+              'de-AT',
+              'de-CH') ) THEN 'NEW_TAB_DE_DE'
+            WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+            WHEN (normalized_country_code IN ('FR')
+            AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+            WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+        END
+          AS feed_name,
+        e.name as event_name,
+        SAFE_CAST(mozfun.map.get_key(e.extra, 'is_sponsored') AS boolean) as is_sponsored,
+        metrics.boolean.pocket_enabled = True as pocket_enabled,
+        metrics.boolean.pocket_sponsored_stories_enabled = True as pocket_sponsored_stories_enabled,
+        client_info.client_id as client_id
+    FROM deduplicated_pings, UNNEST(events) as e
+    --filter to Pocket events
+    WHERE e.category = 'pocket'
+        --limit to impressions and clicks
+        and e.name IN ('impression', 'click')
+        --keep only data with a non-null recommendation ID or tile ID
+        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
+        --include only release channel data
+        and normalized_channel = 'release'
+        --include only data from Firefox 121+
+        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+        --limit to locale & country combinations with Pocket enabled
+        AND ( ( normalized_country_code IN ('US',
+              'CA',
+              'GB',
+              'IE',
+              'IN')
+            AND metrics.string.newtab_locale IN ('en-CA',
+              'en-GB',
+              'en-US') )
+            OR ( normalized_country_code IN ('DE',
+              'CH',
+              'AT',
+              'BE')
+            AND metrics.string.newtab_locale IN ('de',
+              'de-AT',
+              'de-CH') )
+            OR (normalized_country_code IN ('IT')
+            AND metrics.string.newtab_locale IN ('it'))
+            OR (normalized_country_code IN ('FR')
+            AND metrics.string.newtab_locale IN ('fr'))
+            OR (normalized_country_code IN ('ES')
+            AND metrics.string.newtab_locale IN ('es-ES')) )
+)
+
+--let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
+--the duplicate clicks issue we saw with the legacy PingCentre events:
+--https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
+
+SELECT
+  happened_at,
+  feed_name,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'impression' THEN client_id
+  END
+    ) AS users_viewing_recs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'click' THEN client_id
+  END
+    ) AS users_clicking_recs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True THEN client_id
+  END
+    ) AS users_eligible_for_spocs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+  END
+    ) AS users_viewing_spocs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'click' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+  END
+    ) AS users_clicking_spocs_count,
+FROM
+  flattened_pocket_events
+GROUP BY
+  1,
+  2
+ORDER BY
+  1,
+  2
+  {% endif %}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
@@ -9,85 +9,89 @@
 
 WITH
   deduplicated_pings AS (
-    SELECT
-      *   
-    FROM
-      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
-    WHERE submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
-    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
-    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
-    document_id
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+  WHERE
+    submission_timestamp >= {{ helpers.parse_iso8601(batch_start) }}
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
+      document_id
     ORDER BY
-    submission_timestamp desc) = 1
-),
-  flattened_pocket_events as (
-    SELECT
-        DATE(submission_timestamp) as happened_at,
-        CASE
-            WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
-            WHEN ( normalized_country_code IN ('GB',
-              'IE')
-            AND metrics.string.newtab_locale IN ('en-CA',
-              'en-GB',
-              'en-US') ) THEN 'NEW_TAB_EN_GB'
-            WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
-            WHEN ( normalized_country_code IN ('DE',
-              'CH',
-              'AT',
-              'BE')
-            AND metrics.string.newtab_locale IN ('de',
-              'de-AT',
-              'de-CH') ) THEN 'NEW_TAB_DE_DE'
-            WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
-            WHEN (normalized_country_code IN ('FR')
-            AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
-            WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
-        END
-          AS feed_name,
-        e.name as event_name,
-        SAFE_CAST(mozfun.map.get_key(e.extra, 'is_sponsored') AS boolean) as is_sponsored,
-        metrics.boolean.pocket_enabled = True as pocket_enabled,
-        metrics.boolean.pocket_sponsored_stories_enabled = True as pocket_sponsored_stories_enabled,
-        client_info.client_id as client_id
-    FROM deduplicated_pings, UNNEST(events) as e
+      submission_timestamp DESC) = 1 ),
+  flattened_pocket_events AS (
+  SELECT
+    DATE(submission_timestamp) AS happened_at,
+    CASE
+      WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+      WHEN ( normalized_country_code IN ('GB',
+        'IE')
+      AND metrics.string.newtab_locale IN ('en-CA',
+        'en-GB',
+        'en-US') ) THEN 'NEW_TAB_EN_GB'
+      WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+      WHEN ( normalized_country_code IN ('DE',
+        'CH',
+        'AT',
+        'BE')
+      AND metrics.string.newtab_locale IN ('de',
+        'de-AT',
+        'de-CH') ) THEN 'NEW_TAB_DE_DE'
+      WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+      WHEN (normalized_country_code IN ('FR')
+      AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+      WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+  END
+    AS feed_name,
+    e.name AS event_name,
+    SAFE_CAST(mozfun.map.get_key(e.extra,
+        'is_sponsored') AS boolean) AS is_sponsored,
+    metrics.boolean.pocket_enabled = TRUE AS pocket_enabled,
+    metrics.boolean.pocket_sponsored_stories_enabled = TRUE AS pocket_sponsored_stories_enabled,
+    client_info.client_id AS client_id
+  FROM
+    deduplicated_pings,
+    UNNEST(events) AS e
     --filter to Pocket events
-    WHERE e.category = 'pocket'
-        --limit to impressions and clicks
-        and e.name IN ('impression', 'click')
-        --keep only data with a non-null recommendation ID or tile ID
-        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
-        --include only release channel data
-        and normalized_channel = 'release'
-        --include only data from Firefox 121+
-        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
-        --limit to locale & country combinations with Pocket enabled
-        AND ( ( normalized_country_code IN ('US',
-              'CA',
-              'GB',
-              'IE',
-              'IN')
-            AND metrics.string.newtab_locale IN ('en-CA',
-              'en-GB',
-              'en-US') )
-            OR ( normalized_country_code IN ('DE',
-              'CH',
-              'AT',
-              'BE')
-            AND metrics.string.newtab_locale IN ('de',
-              'de-AT',
-              'de-CH') )
-            OR (normalized_country_code IN ('IT')
-            AND metrics.string.newtab_locale IN ('it'))
-            OR (normalized_country_code IN ('FR')
-            AND metrics.string.newtab_locale IN ('fr'))
-            OR (normalized_country_code IN ('ES')
-            AND metrics.string.newtab_locale IN ('es-ES')) )
-)
-
---let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
---the duplicate clicks issue we saw with the legacy PingCentre events:
---https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
-
+  WHERE
+    e.category = 'pocket'
+    --limit to impressions and clicks
+    AND e.name IN ('impression',
+      'click')
+    --keep only data with a non-null recommendation ID or tile ID
+    AND (mozfun.map.get_key(e.extra,
+        'recommendation_id') IS NOT NULL
+      OR mozfun.map.get_key(e.extra,
+        'tile_id') IS NOT NULL)
+    --include only release channel data
+    AND normalized_channel = 'release'
+    --include only data from Firefox 121+
+    AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+    --limit to locale & country combinations with Pocket enabled
+    AND ( ( normalized_country_code IN ('US',
+          'CA',
+          'GB',
+          'IE',
+          'IN')
+        AND metrics.string.newtab_locale IN ('en-CA',
+          'en-GB',
+          'en-US') )
+      OR ( normalized_country_code IN ('DE',
+          'CH',
+          'AT',
+          'BE')
+        AND metrics.string.newtab_locale IN ('de',
+          'de-AT',
+          'de-CH') )
+      OR (normalized_country_code IN ('IT')
+        AND metrics.string.newtab_locale IN ('it'))
+      OR (normalized_country_code IN ('FR')
+        AND metrics.string.newtab_locale IN ('fr'))
+      OR (normalized_country_code IN ('ES')
+        AND metrics.string.newtab_locale IN ('es-ES')) ) )
+  --let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
+  --the duplicate clicks issue we saw with the legacy PingCentre events:
+  --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
 SELECT
   happened_at,
   feed_name,
@@ -103,17 +107,17 @@ SELECT
     ) AS users_clicking_recs_count,
   COUNT(DISTINCT
     CASE
-      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True THEN client_id
+      WHEN event_name= 'impression' AND pocket_enabled = TRUE AND pocket_sponsored_stories_enabled = TRUE THEN client_id
   END
     ) AS users_eligible_for_spocs_count,
   COUNT(DISTINCT
     CASE
-      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+      WHEN event_name= 'impression' AND pocket_enabled = TRUE AND pocket_sponsored_stories_enabled = TRUE AND is_sponsored = TRUE THEN client_id
   END
     ) AS users_viewing_spocs_count,
   COUNT(DISTINCT
     CASE
-      WHEN event_name= 'click' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+      WHEN event_name= 'click' AND pocket_enabled = TRUE AND pocket_sponsored_stories_enabled = TRUE AND is_sponsored = TRUE THEN client_id
   END
     ) AS users_clicking_spocs_count,
 FROM

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/load.sql
@@ -1,0 +1,15 @@
+{% set sql_engine = "snowflake" %}
+{% set is_multi_statement = True %}
+{% import 'helpers.j2' as helpers with context %}
+
+{% macro table_def() %}
+    happened_at date not null,
+    feed_name string,
+    users_viewing_recs_count number not null,
+    users_clicking_recs_count number not null,
+    users_eligible_for_spocs_count number not null,
+    users_viewing_spocs_count number not null,
+    users_clicking_spocs_count number not null 
+{% endmacro %}
+
+{{ helpers.sf_merge(table_def(), 'happened_at') }}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/load.sql
@@ -4,7 +4,7 @@
 
 {% macro table_def() %}
     happened_at date not null,
-    feed_name string,
+    feed_name string not null,
     users_viewing_recs_count number not null,
     users_clicking_recs_count number not null,
     users_eligible_for_spocs_count number not null,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/offset.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/offset.sql
@@ -1,0 +1,2 @@
+{% set sql_engine = "snowflake" %}
+select (trunc(sysdate()::timestamp, 'day') - interval '1 day') - interval '1 microsecond';

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
@@ -91,8 +91,7 @@ WITH
       OR (normalized_country_code IN ('FR')
         AND metrics.string.newtab_locale IN ('fr'))
       OR (normalized_country_code IN ('ES')
-        AND metrics.string.newtab_locale IN ('es-ES')) ) ) /*let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to the duplicate clicks issue we saw with the legacy PingCentre events:
---https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei */
+        AND metrics.string.newtab_locale IN ('es-ES')) ) ) 
 SELECT
   DATE_TRUNC(happened_at, month) AS happened_at,
   feed_name,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
@@ -1,0 +1,131 @@
+{% set sql_engine = "bigquery" %}
+{% import 'helpers.j2' as helpers with context %}
+{% if for_new_offset %}
+    select current_timestamp()
+{% else %}
+{% macro parse_iso8601(datetime) %}
+    PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*SZ', '{{ datetime }}')
+{% endmacro %}
+
+--replicates logic of current Prefect query using Glean data
+--https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily/firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+
+WITH
+  deduplicated_pings AS (
+    SELECT
+      *   
+    FROM
+      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`  
+    WHERE submission_timestamp >= CAST(DATE_SUB(CAST({{ helpers.parse_iso8601(batch_start) }} as DATE), INTERVAL 1 MONTH) as TIMESTAMP)
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
+    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
+    document_id
+    ORDER BY
+    submission_timestamp desc) = 1
+),
+  flattened_pocket_events as (
+    SELECT
+        DATE(submission_timestamp) as happened_at,
+        CASE
+            WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+            WHEN ( normalized_country_code IN ('GB',
+              'IE')
+            AND metrics.string.newtab_locale IN ('en-CA',
+              'en-GB',
+              'en-US') ) THEN 'NEW_TAB_EN_GB'
+            WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+            WHEN ( normalized_country_code IN ('DE',
+              'CH',
+              'AT',
+              'BE')
+            AND metrics.string.newtab_locale IN ('de',
+              'de-AT',
+              'de-CH') ) THEN 'NEW_TAB_DE_DE'
+            WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+            WHEN (normalized_country_code IN ('FR')
+            AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+            WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+        END
+          AS feed_name,
+        e.name as event_name,
+        SAFE_CAST(mozfun.map.get_key(e.extra, 'is_sponsored') AS boolean) as is_sponsored,
+        metrics.boolean.pocket_enabled = True as pocket_enabled,
+        metrics.boolean.pocket_sponsored_stories_enabled = True as pocket_sponsored_stories_enabled,
+        client_info.client_id as client_id
+    FROM deduplicated_pings, UNNEST(events) as e
+    --filter to Pocket events
+    WHERE e.category = 'pocket'
+        --limit to impressions and clicks
+        and e.name IN ('impression', 'click')
+        --keep only data with a non-null recommendation ID or tile ID
+        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
+        --include only release channel data
+        and normalized_channel = 'release'
+        --include only data from Firefox 121+
+        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+        --limit to locale & country combinations with Pocket enabled
+        AND ( ( normalized_country_code IN ('US',
+              'CA',
+              'GB',
+              'IE',
+              'IN')
+            AND metrics.string.newtab_locale IN ('en-CA',
+              'en-GB',
+              'en-US') )
+            OR ( normalized_country_code IN ('DE',
+              'CH',
+              'AT',
+              'BE')
+            AND metrics.string.newtab_locale IN ('de',
+              'de-AT',
+              'de-CH') )
+            OR (normalized_country_code IN ('IT')
+            AND metrics.string.newtab_locale IN ('it'))
+            OR (normalized_country_code IN ('FR')
+            AND metrics.string.newtab_locale IN ('fr'))
+            OR (normalized_country_code IN ('ES')
+            AND metrics.string.newtab_locale IN ('es-ES')) )
+)
+
+/*let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to the duplicate clicks issue we saw with the legacy PingCentre events:
+--https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei */
+
+SELECT
+  DATE_TRUNC(happened_at, month) as happened_at,
+  feed_name,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'impression' THEN client_id
+  END
+    ) AS users_viewing_recs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'click' THEN client_id
+  END
+    ) AS users_clicking_recs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True THEN client_id
+  END
+    ) AS users_eligible_for_spocs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+  END
+    ) AS users_viewing_spocs_count,
+  COUNT(DISTINCT
+    CASE
+      WHEN event_name= 'click' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+  END
+    ) AS users_clicking_spocs_count,
+  CAST({{ helpers.parse_iso8601(batch_start) }} as DATE) as aggregation_date
+FROM
+  flattened_pocket_events
+GROUP BY
+  1,
+  2
+ORDER BY
+  1,
+  2
+
+{% endif %}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/data.sql
@@ -12,86 +12,89 @@
 
 WITH
   deduplicated_pings AS (
-    SELECT
-      *   
-    FROM
-      `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`  
-    WHERE submission_timestamp >= CAST(DATE_SUB(CAST({{ helpers.parse_iso8601(batch_start) }} as DATE), INTERVAL 1 MONTH) as TIMESTAMP)
-    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }}
-    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
-    document_id
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+  WHERE
+    submission_timestamp >= CAST(DATE_SUB(CAST({{ helpers.parse_iso8601(batch_start) }} AS DATE), INTERVAL 1 MONTH) AS TIMESTAMP)
+    AND submission_timestamp < {{ helpers.parse_iso8601(batch_end) }} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
+      document_id
     ORDER BY
-    submission_timestamp desc) = 1
-),
-  flattened_pocket_events as (
-    SELECT
-        DATE(submission_timestamp) as happened_at,
-        CASE
-            WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
-            WHEN ( normalized_country_code IN ('GB',
-              'IE')
-            AND metrics.string.newtab_locale IN ('en-CA',
-              'en-GB',
-              'en-US') ) THEN 'NEW_TAB_EN_GB'
-            WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
-            WHEN ( normalized_country_code IN ('DE',
-              'CH',
-              'AT',
-              'BE')
-            AND metrics.string.newtab_locale IN ('de',
-              'de-AT',
-              'de-CH') ) THEN 'NEW_TAB_DE_DE'
-            WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
-            WHEN (normalized_country_code IN ('FR')
-            AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
-            WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
-        END
-          AS feed_name,
-        e.name as event_name,
-        SAFE_CAST(mozfun.map.get_key(e.extra, 'is_sponsored') AS boolean) as is_sponsored,
-        metrics.boolean.pocket_enabled = True as pocket_enabled,
-        metrics.boolean.pocket_sponsored_stories_enabled = True as pocket_sponsored_stories_enabled,
-        client_info.client_id as client_id
-    FROM deduplicated_pings, UNNEST(events) as e
+      submission_timestamp DESC) = 1 ),
+  flattened_pocket_events AS (
+  SELECT
+    DATE(submission_timestamp) AS happened_at,
+    CASE
+      WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
+      WHEN ( normalized_country_code IN ('GB',
+        'IE')
+      AND metrics.string.newtab_locale IN ('en-CA',
+        'en-GB',
+        'en-US') ) THEN 'NEW_TAB_EN_GB'
+      WHEN ( normalized_country_code IN ('IN') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_INTL'
+      WHEN ( normalized_country_code IN ('DE',
+        'CH',
+        'AT',
+        'BE')
+      AND metrics.string.newtab_locale IN ('de',
+        'de-AT',
+        'de-CH') ) THEN 'NEW_TAB_DE_DE'
+      WHEN (normalized_country_code IN ('IT') AND metrics.string.newtab_locale IN ('it')) THEN 'NEW_TAB_IT_IT'
+      WHEN (normalized_country_code IN ('FR')
+      AND metrics.string.newtab_locale IN ('fr')) THEN 'NEW_TAB_FR_FR'
+      WHEN (normalized_country_code IN ('ES') AND metrics.string.newtab_locale IN ('es-ES')) THEN 'NEW_TAB_ES_ES'
+  END
+    AS feed_name,
+    e.name AS event_name,
+    SAFE_CAST(mozfun.map.get_key(e.extra,
+        'is_sponsored') AS boolean) AS is_sponsored,
+    metrics.boolean.pocket_enabled = TRUE AS pocket_enabled,
+    metrics.boolean.pocket_sponsored_stories_enabled = TRUE AS pocket_sponsored_stories_enabled,
+    client_info.client_id AS client_id
+  FROM
+    deduplicated_pings,
+    UNNEST(events) AS e
     --filter to Pocket events
-    WHERE e.category = 'pocket'
-        --limit to impressions and clicks
-        and e.name IN ('impression', 'click')
-        --keep only data with a non-null recommendation ID or tile ID
-        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
-        --include only release channel data
-        and normalized_channel = 'release'
-        --include only data from Firefox 121+
-        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
-        --limit to locale & country combinations with Pocket enabled
-        AND ( ( normalized_country_code IN ('US',
-              'CA',
-              'GB',
-              'IE',
-              'IN')
-            AND metrics.string.newtab_locale IN ('en-CA',
-              'en-GB',
-              'en-US') )
-            OR ( normalized_country_code IN ('DE',
-              'CH',
-              'AT',
-              'BE')
-            AND metrics.string.newtab_locale IN ('de',
-              'de-AT',
-              'de-CH') )
-            OR (normalized_country_code IN ('IT')
-            AND metrics.string.newtab_locale IN ('it'))
-            OR (normalized_country_code IN ('FR')
-            AND metrics.string.newtab_locale IN ('fr'))
-            OR (normalized_country_code IN ('ES')
-            AND metrics.string.newtab_locale IN ('es-ES')) )
-)
-
-/*let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to the duplicate clicks issue we saw with the legacy PingCentre events:
+  WHERE
+    e.category = 'pocket'
+    --limit to impressions and clicks
+    AND e.name IN ('impression',
+      'click')
+    --keep only data with a non-null recommendation ID or tile ID
+    AND (mozfun.map.get_key(e.extra,
+        'recommendation_id') IS NOT NULL
+      OR mozfun.map.get_key(e.extra,
+        'tile_id') IS NOT NULL)
+    --include only release channel data
+    AND normalized_channel = 'release'
+    --include only data from Firefox 121+
+    AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+    --limit to locale & country combinations with Pocket enabled
+    AND ( ( normalized_country_code IN ('US',
+          'CA',
+          'GB',
+          'IE',
+          'IN')
+        AND metrics.string.newtab_locale IN ('en-CA',
+          'en-GB',
+          'en-US') )
+      OR ( normalized_country_code IN ('DE',
+          'CH',
+          'AT',
+          'BE')
+        AND metrics.string.newtab_locale IN ('de',
+          'de-AT',
+          'de-CH') )
+      OR (normalized_country_code IN ('IT')
+        AND metrics.string.newtab_locale IN ('it'))
+      OR (normalized_country_code IN ('FR')
+        AND metrics.string.newtab_locale IN ('fr'))
+      OR (normalized_country_code IN ('ES')
+        AND metrics.string.newtab_locale IN ('es-ES')) ) ) /*let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to the duplicate clicks issue we saw with the legacy PingCentre events:
 --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei */
-
 SELECT
-  DATE_TRUNC(happened_at, month) as happened_at,
+  DATE_TRUNC(happened_at, month) AS happened_at,
   feed_name,
   COUNT(DISTINCT
     CASE
@@ -105,20 +108,20 @@ SELECT
     ) AS users_clicking_recs_count,
   COUNT(DISTINCT
     CASE
-      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True THEN client_id
+      WHEN event_name= 'impression' AND pocket_enabled = TRUE AND pocket_sponsored_stories_enabled = TRUE THEN client_id
   END
     ) AS users_eligible_for_spocs_count,
   COUNT(DISTINCT
     CASE
-      WHEN event_name= 'impression' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+      WHEN event_name= 'impression' AND pocket_enabled = TRUE AND pocket_sponsored_stories_enabled = TRUE AND is_sponsored = TRUE THEN client_id
   END
     ) AS users_viewing_spocs_count,
   COUNT(DISTINCT
     CASE
-      WHEN event_name= 'click' AND pocket_enabled = True AND pocket_sponsored_stories_enabled = True AND is_sponsored = True THEN client_id
+      WHEN event_name= 'click' AND pocket_enabled = TRUE AND pocket_sponsored_stories_enabled = TRUE AND is_sponsored = TRUE THEN client_id
   END
     ) AS users_clicking_spocs_count,
-  CAST({{ helpers.parse_iso8601(batch_start) }} as DATE) as aggregation_date
+  CAST({{ helpers.parse_iso8601(batch_start) }} AS DATE) AS aggregation_date
 FROM
   flattened_pocket_events
 GROUP BY

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/load.sql
@@ -1,0 +1,16 @@
+{% set sql_engine = "snowflake" %}
+{% set is_multi_statement = True %}
+{% import 'helpers.j2' as helpers with context %}
+
+{% macro table_def() %}
+    happened_at date not null,
+    feed_name string,
+    users_viewing_recs_count number not null,
+    users_clicking_recs_count number not null,
+    users_eligible_for_spocs_count number not null,
+    users_viewing_spocs_count number not null,
+    users_clicking_spocs_count number not null,
+    aggregation_date date not null
+{% endmacro %}
+
+{{ helpers.sf_merge(table_def(), 'aggregation_date') }}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/load.sql
@@ -4,7 +4,7 @@
 
 {% macro table_def() %}
     happened_at date not null,
-    feed_name string,
+    feed_name string not null,
     users_viewing_recs_count number not null,
     users_clicking_recs_count number not null,
     users_eligible_for_spocs_count number not null,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/offset.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/offset.sql
@@ -1,2 +1,3 @@
 {% set sql_engine = "snowflake" %}
-select (trunc(sysdate()::timestamp, 'day') - interval '1 day') - interval '1 microsecond';
+select
+    (trunc(sysdate()::timestamp, 'day') - interval '1 day') - interval '1 microsecond';

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/offset.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_monthly_unique_engagement_by_feed/offset.sql
@@ -1,0 +1,2 @@
+{% set sql_engine = "snowflake" %}
+select (trunc(sysdate()::timestamp, 'day') - interval '1 day') - interval '1 microsecond';

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -1,0 +1,51 @@
+{% set sql_engine = "bigquery" %}
+{% import 'helpers.j2' as helpers with context %}
+
+--replicates logic of current Prefect query using Glean data
+--https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly/firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+
+WITH
+  deduplicated_pings AS (
+    SELECT
+      *   
+    FROM `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+    {{helpers.legacy_rolling_24_hours_filter()}}
+    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
+    document_id
+    ORDER BY
+    submission_timestamp desc) = 1
+),
+flattened_pocket_events as (
+    SELECT
+        submission_timestamp,
+        e.name as event_name,
+        mozfun.map.get_key(e.extra, 'recommendation_id') as recommendation_id,
+        mozfun.map.get_key(e.extra, 'tile_id') as tile_id,
+        mozfun.map.get_key(e.extra, 'position') as position
+    FROM deduplicated_pings, UNNEST(events) as e
+    --filter to Pocket events
+    WHERE e.category = 'pocket'
+        and e.name in ('impression', 'click', 'save', 'dismiss')
+        --keep only data with a non-null recommendation ID or tile ID
+        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
+        --include only data from Firefox 121+
+        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+)
+
+--let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
+--the duplicate clicks issue we saw with the legacy PingCentre events:
+--https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
+
+SELECT
+    DATE(submission_timestamp) AS happened_at,
+    recommendation_id,
+    tile_id,
+    position,
+    
+    SUM(CASE WHEN event_name = 'impression' then 1 else 0 end) as impression_count,
+    SUM(CASE WHEN event_name = 'click' then 1 else 0 end) as click_count,
+    SUM(CASE WHEN event_name = 'save' then 1 else 0 end) as save_count,
+    SUM(CASE WHEN event_name = 'dismiss' then 1 else 0 end) as dismiss_count
+    
+FROM flattened_pocket_events
+GROUP BY 1, 2, 3, 4

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -6,46 +6,77 @@
 
 WITH
   deduplicated_pings AS (
-    SELECT
-      *   
-    FROM `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
-    {{helpers.legacy_rolling_24_hours_filter()}}
-    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
-    document_id
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1` {{helpers.legacy_rolling_24_hours_filter()}} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
+      document_id
     ORDER BY
-    submission_timestamp desc) = 1
-),
-flattened_pocket_events as (
-    SELECT
-        submission_timestamp,
-        e.name as event_name,
-        mozfun.map.get_key(e.extra, 'recommendation_id') as recommendation_id,
-        mozfun.map.get_key(e.extra, 'tile_id') as tile_id,
-        mozfun.map.get_key(e.extra, 'position') as position
-    FROM deduplicated_pings, UNNEST(events) as e
+      submission_timestamp DESC) = 1 ),
+  flattened_pocket_events AS (
+  SELECT
+    submission_timestamp,
+    e.name AS event_name,
+    mozfun.map.get_key(e.extra,
+      'recommendation_id') AS recommendation_id,
+    mozfun.map.get_key(e.extra,
+      'tile_id') AS tile_id,
+    mozfun.map.get_key(e.extra,
+      'position') AS position
+  FROM
+    deduplicated_pings,
+    UNNEST(events) AS e
     --filter to Pocket events
-    WHERE e.category = 'pocket'
-        and e.name in ('impression', 'click', 'save', 'dismiss')
-        --keep only data with a non-null recommendation ID or tile ID
-        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
-        --include only data from Firefox 121+
-        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
-)
-
---let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
---the duplicate clicks issue we saw with the legacy PingCentre events:
---https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
-
+  WHERE
+    e.category = 'pocket'
+    AND e.name IN ('impression',
+      'click',
+      'save',
+      'dismiss')
+    --keep only data with a non-null recommendation ID or tile ID
+    AND (mozfun.map.get_key(e.extra,
+        'recommendation_id') IS NOT NULL
+      OR mozfun.map.get_key(e.extra,
+        'tile_id') IS NOT NULL)
+    --include only data from Firefox 121+
+    AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121 )
+  --let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
+  --the duplicate clicks issue we saw with the legacy PingCentre events:
+  --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
 SELECT
-    DATE(submission_timestamp) AS happened_at,
-    recommendation_id,
-    tile_id,
-    position,
-    
-    SUM(CASE WHEN event_name = 'impression' then 1 else 0 end) as impression_count,
-    SUM(CASE WHEN event_name = 'click' then 1 else 0 end) as click_count,
-    SUM(CASE WHEN event_name = 'save' then 1 else 0 end) as save_count,
-    SUM(CASE WHEN event_name = 'dismiss' then 1 else 0 end) as dismiss_count
-    
-FROM flattened_pocket_events
-GROUP BY 1, 2, 3, 4
+  DATE(submission_timestamp) AS happened_at,
+  recommendation_id,
+  tile_id,
+  position,
+  SUM(CASE
+      WHEN event_name = 'impression' THEN 1
+    ELSE
+    0
+  END
+    ) AS impression_count,
+  SUM(CASE
+      WHEN event_name = 'click' THEN 1
+    ELSE
+    0
+  END
+    ) AS click_count,
+  SUM(CASE
+      WHEN event_name = 'save' THEN 1
+    ELSE
+    0
+  END
+    ) AS save_count,
+  SUM(CASE
+      WHEN event_name = 'dismiss' THEN 1
+    ELSE
+    0
+  END
+    ) AS dismiss_count
+FROM
+  flattened_pocket_events
+GROUP BY
+  1,
+  2,
+  3,
+  4
+  

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -40,9 +40,6 @@ WITH
         'tile_id') IS NOT NULL)
     --include only data from Firefox 121+
     AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121 )
-  --let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
-  --the duplicate clicks issue we saw with the legacy PingCentre events:
-  --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
 SELECT
   DATE(submission_timestamp) AS happened_at,
   recommendation_id,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/load.sql
@@ -1,0 +1,16 @@
+{% set sql_engine = "snowflake" %}
+{% set is_multi_statement = True %}
+{% import 'helpers.j2' as helpers with context %}
+
+{% macro table_def() %}
+    happened_at date not null,
+    recommendation_id string, 
+    tile_id number,
+    position number not null,
+    impression_count number not null,
+    click_count number not null,
+    save_count number not null,
+    dismiss_count number not null 
+{% endmacro %}
+
+{{ helpers.sf_merge(table_def(), 'happened_at') }}

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -6,51 +6,84 @@
 
 WITH
   deduplicated_pings AS (
-    SELECT
-      *   
-    FROM `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
-    {{helpers.legacy_rolling_24_hours_filter()}}
-    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
-    document_id
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1` {{helpers.legacy_rolling_24_hours_filter()}} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
+      document_id
     ORDER BY
-    submission_timestamp desc) = 1
-),
-flattened_pocket_events as (
-    SELECT
-        submission_timestamp,
-        e.name as event_name,
-        mozfun.map.get_key(e.extra, 'recommendation_id') as recommendation_id,
-        mozfun.map.get_key(e.extra, 'tile_id') as tile_id,
-        mozfun.map.get_key(e.extra, 'position') as position,
-        metrics.string.newtab_locale as locale,
-        normalized_country_code as country
-    FROM deduplicated_pings, UNNEST(events) as e
+      submission_timestamp DESC) = 1 ),
+  flattened_pocket_events AS (
+  SELECT
+    submission_timestamp,
+    e.name AS event_name,
+    mozfun.map.get_key(e.extra,
+      'recommendation_id') AS recommendation_id,
+    mozfun.map.get_key(e.extra,
+      'tile_id') AS tile_id,
+    mozfun.map.get_key(e.extra,
+      'position') AS position,
+    metrics.string.newtab_locale AS locale,
+    normalized_country_code AS country
+  FROM
+    deduplicated_pings,
+    UNNEST(events) AS e
     --filter to Pocket events
-    WHERE e.category = 'pocket'
-        and e.name in ('impression', 'click', 'save', 'dismiss')
-        --keep only data with a non-null recommendation ID or tile ID
-        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
-        --include only data from Firefox 121+
-        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
-)
-
---let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
---the duplicate clicks issue we saw with the legacy PingCentre events:
---https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
-
+  WHERE
+    e.category = 'pocket'
+    AND e.name IN ('impression',
+      'click',
+      'save',
+      'dismiss')
+    --keep only data with a non-null recommendation ID or tile ID
+    AND (mozfun.map.get_key(e.extra,
+        'recommendation_id') IS NOT NULL
+      OR mozfun.map.get_key(e.extra,
+        'tile_id') IS NOT NULL)
+    --include only data from Firefox 121+
+    AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121 )
+  --let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
+  --the duplicate clicks issue we saw with the legacy PingCentre events:
+  --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
 SELECT
-    DATE(submission_timestamp) AS happened_at,
-    recommendation_id,
-    tile_id,
-    position,
-    'CARDGRID' as source,
-    locale,
-    country,
-    
-    SUM(CASE WHEN event_name = 'impression' then 1 else 0 end) as impression_count,
-    SUM(CASE WHEN event_name = 'click' then 1 else 0 end) as click_count,
-    SUM(CASE WHEN event_name = 'save' then 1 else 0 end) as save_count,
-    SUM(CASE WHEN event_name = 'dismiss' then 1 else 0 end) as dismiss_count
-    
-FROM flattened_pocket_events
-GROUP BY 1, 2, 3, 4, 5, 6, 7
+  DATE(submission_timestamp) AS happened_at,
+  recommendation_id,
+  tile_id,
+  position,
+  'CARDGRID' AS SOURCE,
+  locale,
+  country,
+  SUM(CASE
+      WHEN event_name = 'impression' THEN 1
+    ELSE
+    0
+  END
+    ) AS impression_count,
+  SUM(CASE
+      WHEN event_name = 'click' THEN 1
+    ELSE
+    0
+  END
+    ) AS click_count,
+  SUM(CASE
+      WHEN event_name = 'save' THEN 1
+    ELSE
+    0
+  END
+    ) AS save_count,
+  SUM(CASE
+      WHEN event_name = 'dismiss' THEN 1
+    ELSE
+    0
+  END
+    ) AS dismiss_count
+FROM
+  flattened_pocket_events
+GROUP BY
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -1,0 +1,56 @@
+{% set sql_engine = "bigquery" %}
+{% import 'helpers.j2' as helpers with context %}
+
+--replicates logic of current Prefect query using Glean data
+--https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly/firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+
+WITH
+  deduplicated_pings AS (
+    SELECT
+      *   
+    FROM `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
+    {{helpers.legacy_rolling_24_hours_filter()}}
+    QUALIFY row_number() over (PARTITION BY DATE(submission_timestamp),
+    document_id
+    ORDER BY
+    submission_timestamp desc) = 1
+),
+flattened_pocket_events as (
+    SELECT
+        submission_timestamp,
+        e.name as event_name,
+        mozfun.map.get_key(e.extra, 'recommendation_id') as recommendation_id,
+        mozfun.map.get_key(e.extra, 'tile_id') as tile_id,
+        mozfun.map.get_key(e.extra, 'position') as position,
+        metrics.string.newtab_locale as locale,
+        normalized_country_code as country
+    FROM deduplicated_pings, UNNEST(events) as e
+    --filter to Pocket events
+    WHERE e.category = 'pocket'
+        and e.name in ('impression', 'click', 'save', 'dismiss')
+        --keep only data with a non-null recommendation ID or tile ID
+        and (mozfun.map.get_key(e.extra, 'recommendation_id') is not null or mozfun.map.get_key(e.extra, 'tile_id') is not null)
+        --include only data from Firefox 121+
+        and SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121
+)
+
+--let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
+--the duplicate clicks issue we saw with the legacy PingCentre events:
+--https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
+
+SELECT
+    DATE(submission_timestamp) AS happened_at,
+    recommendation_id,
+    tile_id,
+    position,
+    'CARDGRID' as source,
+    locale,
+    country,
+    
+    SUM(CASE WHEN event_name = 'impression' then 1 else 0 end) as impression_count,
+    SUM(CASE WHEN event_name = 'click' then 1 else 0 end) as click_count,
+    SUM(CASE WHEN event_name = 'save' then 1 else 0 end) as save_count,
+    SUM(CASE WHEN event_name = 'dismiss' then 1 else 0 end) as dismiss_count
+    
+FROM flattened_pocket_events
+GROUP BY 1, 2, 3, 4, 5, 6, 7

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -42,9 +42,6 @@ WITH
         'tile_id') IS NOT NULL)
     --include only data from Firefox 121+
     AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121 )
-  --let's skip the usual click deduplication step, Jeff Silverman's analysis showed that Glean is resistant to
-  --the duplicate clicks issue we saw with the legacy PingCentre events:
-  --https://docs.google.com/document/d/1aL3bjJ6PQLHH455zCMReDpYnyqPTNwTvTW2QujwP-nw/edit#heading=h.bz9b6bjjzei
 SELECT
   DATE(submission_timestamp) AS happened_at,
   recommendation_id,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/load.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/load.sql
@@ -1,0 +1,19 @@
+{% set sql_engine = "snowflake" %}
+{% set is_multi_statement = True %}
+{% import 'helpers.j2' as helpers with context %}
+
+{% macro table_def() %}
+    happened_at date not null,
+    recommendation_id string,
+    tile_id number,
+    position number not null,
+    source string,
+    locale string,
+    country string,
+    impression_count number not null,
+    click_count number not null,
+    save_count number not null,
+    dismiss_count number not null 
+{% endmacro %}
+
+{{ helpers.sf_merge(table_def(), 'happened_at') }}


### PR DESCRIPTION
## Goal
What changed? What is the business/product goal?

- New extractions are being added to replace activity stream source table with new glean data (activity stream is being retired)

## Implementation Decisions
 These changes are nearly a replica of existing jobs [1](https://github.com/Pocket/data-flows/tree/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_daily) [2](https://github.com/Pocket/data-flows/tree/main-v2/data-products/src/sql_etl/sql/firefox_new_tab_impressions_hourly). The difference is that we are pulling from a different dataset `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1` - to differentiate, the new resulting tables are prefixed w/ glean_

## Deployment steps
- n/a Database migrations?
- n/a Secrets?
- [ ] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):
> Write a #changelog message using our [best practices](https://docs.google.com/document/d/1oEt8Mtkp-6Xz9S2zaNX1EIXfQIEDN2JpY0diuPc1HZc/edit) if this PR (potentially) impacts users. Describe the 'why' and 'what'. @mention relevant teams. Link to this PR.

JIRA ticket:
https://mozilla-hub.atlassian.net/browse/MSDO-63 
