### PR TITLE
feat(data-products): adding sla tags and migrating remaining flows to worker based deployment

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.13.3"
+version = "0.14.0"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -390,7 +390,7 @@ async def etl(
 
 
 # running with dask runner with explicit settings for mutliprocessing
-@flow()  # type: ignore
+@flow(name="article-text-streaming.main")  # type: ignore
 async def main():
     logger = get_run_logger()
     # sinlge object to pass to aws functions

--- a/data-products/src/braze/update_flow.py
+++ b/data-products/src/braze/update_flow.py
@@ -309,9 +309,11 @@ def get_attributes_for_user_deltas(
     return [
         models.UserAttributes(
             external_id=user_delta.external_id,
-            user_alias=models.UserAlias(EMAIL_ALIAS_LABEL, user_delta.email)
-            if not user_delta.external_id
-            else None,
+            user_alias=(
+                models.UserAlias(EMAIL_ALIAS_LABEL, user_delta.email)
+                if not user_delta.external_id
+                else None
+            ),
             _update_existing_only=True,  # Do not create new profiles if one does not exist.
             email=user_delta.email,
             is_premium=user_delta.is_premium,
@@ -334,9 +336,11 @@ def get_events_for_user_deltas(
     return [
         models.UserEvent(
             external_id=user_delta.external_id,
-            user_alias=models.UserAlias("email", user_delta.email)
-            if not user_delta.external_id
-            else None,
+            user_alias=(
+                models.UserAlias("email", user_delta.email)
+                if not user_delta.external_id
+                else None
+            ),
             name=user_delta.braze_event_name,
             properties=get_event_properties_for_user_delta(user_delta),
             time=format_date(user_delta.happened_at),
@@ -504,7 +508,9 @@ FLOW_SPEC = FlowSpec(
     docker_env="base",
     deployments=[
         FlowDeployment(
-            name="update-braze", job_variables={"cpu": 4096, "memory": 30720}
+            name="update-braze",
+            job_variables={"cpu": 4096, "memory": 30720},
+            tags=["hourly-sla"],
         ),
     ],
 )

--- a/data-products/src/data_retention/deleted_accounts_flow.py
+++ b/data-products/src/data_retention/deleted_accounts_flow.py
@@ -52,6 +52,10 @@ FLOW_SPEC = FlowSpec(
     flow=delete_deleted_account_data,
     docker_env="base",
     deployments=[
-        FlowDeployment(name="deployment", cron="0 0 15 * *"),
+        FlowDeployment(
+            name="deployment",
+            cron="0 0 15 * *",
+            tags=["monthly-sla"],
+        ),
     ],
 )

--- a/data-products/src/data_retention/development_snowflake_schemas_flow.py
+++ b/data-products/src/data_retention/development_snowflake_schemas_flow.py
@@ -2,6 +2,7 @@
 
 Reference: https://getpocket.atlassian.net/wiki/spaces/CP/pages/2703949851/Snowflake+Data+Deletion+and+Retention
 """
+
 from common.databases.snowflake_utils import MozSnowflakeConnector
 from common.deployment.worker import FlowDeployment, FlowSpec
 from prefect import flow, unmapped
@@ -28,7 +29,11 @@ FLOW_SPEC = FlowSpec(
     flow=delete_old_dev_schemas,
     docker_env="base",
     deployments=[
-        FlowDeployment(name="deployment", cron="0 0 * * *"),
+        FlowDeployment(
+            name="deployment",
+            cron="0 0 * * *",
+            tags=["daily-sla"],
+        ),
     ],
 )
 

--- a/data-products/src/freestar_revenue_reporting/freestar_reporting_flow.py
+++ b/data-products/src/freestar_revenue_reporting/freestar_reporting_flow.py
@@ -448,6 +448,7 @@ FLOW_SPEC = FlowSpec(
     docker_env="base",
     deployments=[
         FlowDeployment(
+            tags=["daily-sla"],
             name="freestar_extraction",
             # Running at 10 a.m. UTC to ensure it runs after midnight
             # since we are pulling from Freestar's "Yesterday"

--- a/data-products/src/new_tab_recommendations/aggregate_engagement_flow.py
+++ b/data-products/src/new_tab_recommendations/aggregate_engagement_flow.py
@@ -241,6 +241,7 @@ FLOW_SPEC = FlowSpec(
     deployments=[
         FlowDeployment(
             name="deployment",
+            tags=["hourly-sla"],
             cron="*/15 * * * *",
             job_variables={
                 "cpu": 4096,

--- a/data-products/src/prospecting/publisher_features_flow.py
+++ b/data-products/src/prospecting/publisher_features_flow.py
@@ -81,6 +81,7 @@ FLOW_SPEC = FlowSpec(
     docker_env="base",
     deployments=[
         FlowDeployment(
+            tags=["daily-sla"],
             name="publisher_features",
             cron="0 7 * * *",
             timezone="America/Chicago",

--- a/data-products/src/recommendation_api/corpus_candidate_sets_flow.py
+++ b/data-products/src/recommendation_api/corpus_candidate_sets_flow.py
@@ -145,6 +145,7 @@ FLOW_SPEC = FlowSpec(
     deployments=[
         FlowDeployment(
             name="deployment",
+            tags=["hourly-sla"],
             cron="*/60 * * * *",
             job_variables={
                 "cpu": 4096,

--- a/data-products/src/recommendation_api/corpus_item_engagement_flow.py
+++ b/data-products/src/recommendation_api/corpus_item_engagement_flow.py
@@ -50,6 +50,7 @@ FLOW_SPEC = FlowSpec(
     docker_env="base",
     deployments=[
         FlowDeployment(
+            tags=["daily-sla"],
             name="deployment",
             job_variables={
                 "cpu": 4096,

--- a/data-products/src/recommendation_api/legacy_candidate_sets_flow.py
+++ b/data-products/src/recommendation_api/legacy_candidate_sets_flow.py
@@ -258,27 +258,34 @@ FLOW_SPEC = FlowSpec(
     docker_env="base",
     deployments=[
         FlowDeployment(
-            name="topics", cron="*/30 * * * *", parameters={"set_params_id": "topics"}
+            name="topics",
+            cron="*/30 * * * *",
+            parameters={"set_params_id": "topics"},
+            tags=["hourly-sla"],
         ),
         FlowDeployment(
             name="longreads",
             cron="*/180 * * * *",
             parameters={"set_params_id": "longreads"},
+            tags=["3-hour-sla"],
         ),
         FlowDeployment(
             name="shortreads",
             cron="*/180 * * * *",
             parameters={"set_params_id": "shortreads"},
+            tags=["3-hour-sla"],
         ),
         FlowDeployment(
             name="curated_feeds",
             cron="*/60 * * * *",
             parameters={"set_params_id": "curated_feeds"},
+            tags=["hourly-sla"],
         ),
         FlowDeployment(
             name="syndicated_feed",
             cron="*/60 * * * *",
             parameters={"set_params_id": "syndicated_feed"},
+            tags=["hourly-sla"],
         ),
     ],
 )

--- a/data-products/src/recommendation_api/user_impressions_flow.py
+++ b/data-products/src/recommendation_api/user_impressions_flow.py
@@ -85,6 +85,7 @@ FLOW_SPEC = FlowSpec(
                 "cpu": 4096,
                 "memory": 8192,
             },
+            tags=["daily-sla"],
         ),
     ],
 )

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -9,10 +9,9 @@ from common.databases.snowflake_utils import (
     SnowflakeGcsStageSettings,
     get_gcs_stage,
 )
-from common.deployment import FlowDeployment, FlowEnvar, FlowSpec
+from common.deployment.worker import FlowDeployment, FlowSpec
 from common.settings import CommonSettings, get_cached_settings
 from prefect import flow, get_run_logger
-from prefect.server.schemas.schedules import CronSchedule
 from shared.async_utils import process_parallel_subflows
 from shared.utils import (
     IntervalSet,
@@ -434,28 +433,11 @@ SF_GCP_STAGE_ID = CS.deployment_type_value(
 FLOW_SPEC = FlowSpec(
     flow=main,
     docker_env="base",
-    secrets=[
-        FlowEnvar(
-            envar_name="DF_CONFIG_SNOWFLAKE_CREDENTIALS",
-            envar_value=f"data-flows/{CS.deployment_type}/snowflake-credentials",
-        ),
-        FlowEnvar(
-            envar_name="DF_CONFIG_GCP_CREDENTIALS",
-            envar_value=f"data-flows/{CS.deployment_type}/gcp-credentials",
-        ),
-        FlowEnvar(
-            envar_name="DF_CONFIG_SNOWFLAKE_GCP_STAGES",
-            envar_value=f"data-flows/{CS.deployment_type}/snowflake-gcp-stage-data",
-        ),
-        FlowEnvar(
-            envar_name="DF_CONFIG_SQLALCHEMY_CREDENTIALS",
-            envar_value=f"data-flows/{CS.deployment_type}/aurora-rds",
-        ),
-    ],
     deployments=[
         FlowDeployment(
-            deployment_name="backend_events_for_mozilla",
-            schedule=CronSchedule(cron="0 1 * * *", timezone="America/Los_Angeles"),
+            name="backend_events_for_mozilla",
+            cron="0 1 * * *",
+            timezone="America/Los_Angeles",
             parameters={
                 "etl_input": SqlEtlJob(
                     sql_folder_name="backend_events_for_mozilla",
@@ -469,18 +451,18 @@ FLOW_SPEC = FlowSpec(
                     snowflake_stage_id=SF_GCP_STAGE_ID,
                 ).dict()  # type: ignore
             },
-            envars=[
-                FlowEnvar(
-                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
-                    envar_value=CS.deployment_type_value(
+            job_variables={
+                "env": {
+                    "DF_CONFIG_SNOWFLAKE_SCHEMA": CS.deployment_type_value(
                         dev="braun", staging="staging", main="public"
-                    ),  # type: ignore
-                ),
-            ],
+                    )
+                },
+            },
+            tags=["daily-sla"],
         ),
         FlowDeployment(
-            deployment_name="curated_feed_exports_aurora",
-            schedule=CronSchedule(cron="0 * * * *"),
+            name="curated_feed_exports_aurora",
+            cron="0 * * * *",
             parameters={
                 "etl_input": SqlEtlJob(
                     sql_folder_name="curated_feed_exports_aurora",
@@ -489,82 +471,82 @@ FLOW_SPEC = FlowSpec(
                     },
                 ).dict()  # type: ignore
             },
-            envars=[
-                FlowEnvar(
-                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
-                    envar_value=CS.deployment_type_value(
+            job_variables={
+                "env": {
+                    "DF_CONFIG_SNOWFLAKE_SCHEMA": CS.deployment_type_value(
                         dev="braun", staging="staging", main="mysql"
-                    ),  # type: ignore
-                ),
-            ],
+                    )
+                },
+            },
+            tags=["hourly-sla"],
         ),
         FlowDeployment(
-            deployment_name="firefox_new_tab_impressions_daily",
-            schedule=CronSchedule(cron="0 6 * * *"),
+            name="firefox_new_tab_impressions_daily",
+            cron="0 6 * * *",
             parameters={
                 "etl_input": SqlEtlJob(
                     sql_folder_name="firefox_new_tab_impressions_daily"
                 ).dict()  # type: ignore
             },
-            envars=[
-                FlowEnvar(
-                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
-                    envar_value=CS.deployment_type_value(
+            job_variables={
+                "env": {
+                    "DF_CONFIG_SNOWFLAKE_SCHEMA": CS.deployment_type_value(
                         dev="braun", staging="staging", main="mozilla"
-                    ),  # type: ignore
-                ),
-            ],
+                    )
+                },
+            },
+            tags=["daily-sla"],
         ),
         FlowDeployment(
-            deployment_name="firefox_new_tab_impressions_hourly",
-            schedule=CronSchedule(cron="0 * * * *"),
+            name="firefox_new_tab_impressions_hourly",
+            cron="0 * * * *",
             parameters={
                 "etl_input": SqlEtlJob(
                     sql_folder_name="firefox_new_tab_impressions_hourly"
                 ).dict()  # type: ignore
             },
-            envars=[
-                FlowEnvar(
-                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
-                    envar_value=CS.deployment_type_value(
+            job_variables={
+                "env": {
+                    "DF_CONFIG_SNOWFLAKE_SCHEMA": CS.deployment_type_value(
                         dev="braun", staging="staging", main="mozilla"
-                    ),  # type: ignore
-                ),
-            ],
+                    )
+                },
+            },
+            tags=["hourly-sla"],
         ),
         FlowDeployment(
-            deployment_name="glean_firefox_new_tab_impressions_daily",
-            schedule=CronSchedule(cron="0 6 * * *"),
+            name="glean_firefox_new_tab_impressions_daily",
+            cron="0 6 * * *",
             parameters={
                 "etl_input": SqlEtlJob(
                     sql_folder_name="glean_firefox_new_tab_impressions_daily"
                 ).dict()  # type: ignore
             },
-            envars=[
-                FlowEnvar(
-                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
-                    envar_value=CS.deployment_type_value(
-                        dev="cbeck", staging="staging", main="mozilla"
-                    ),  # type: ignore
-                ),
-            ],
+            job_variables={
+                "env": {
+                    "DF_CONFIG_SNOWFLAKE_SCHEMA": CS.deployment_type_value(
+                        dev="braun", staging="staging", main="mozilla"
+                    )
+                },
+            },
+            tags=["daily-sla"],
         ),
         FlowDeployment(
-            deployment_name="glean_firefox_new_tab_impressions_hourly",
-            schedule=CronSchedule(cron="0 * * * *"),
+            name="glean_firefox_new_tab_impressions_hourly",
+            cron="0 * * * *",
             parameters={
                 "etl_input": SqlEtlJob(
                     sql_folder_name="glean_firefox_new_tab_impressions_hourly"
                 ).dict()  # type: ignore
             },
-            envars=[
-                FlowEnvar(
-                    envar_name="DF_CONFIG_SNOWFLAKE_SCHEMA",
-                    envar_value=CS.deployment_type_value(
-                        dev="cbeck", staging="staging", main="mozilla"
-                    ),  # type: ignore
-                ),
-            ],
+            job_variables={
+                "env": {
+                    "DF_CONFIG_SNOWFLAKE_SCHEMA": CS.deployment_type_value(
+                        dev="braun", staging="staging", main="mozilla"
+                    )
+                },
+            },
+            tags=["hourly-sla"],
         ),
     ],
 )

--- a/data-products/src/sql_etl/run_jobs_flow.py
+++ b/data-products/src/sql_etl/run_jobs_flow.py
@@ -368,7 +368,10 @@ async def interval(etl_input: SqlEtlJob, interval_input: IntervalSet):
             logger.info(persist_offset)
 
 
-@flow(description="Interval flow for query based extractions from Snowflake.")
+@flow(
+    description="Interval flow for query based extractions from Snowflake.",
+    name="sql-etl.main",
+)
 async def main(etl_input: SqlEtlJob):
     """Main flow for iterating through etl intervals.
 

--- a/data-products/src/update_pocket_score_data_flow.py
+++ b/data-products/src/update_pocket_score_data_flow.py
@@ -295,6 +295,7 @@ FLOW_SPEC = FlowSpec(
                 "cpu": 2048,
                 "memory": 4096,
             },
+            tags=["hourly-sla"],
         ),
     ],
 )


### PR DESCRIPTION

## Goal
What changed? What is the business/product goal?

- Adding SLA tags for new monitoring created in Prefect Cloud
- Needed to move the remaining flows off agent based deployment since Prefect will be deprecating.  Will remove infra for agents in April 2024.