### PR TITLE
fix(sql_etl): the hourly glean extract can send a string as the position value

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.4"
+version = "0.14.5"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -44,7 +44,7 @@ SELECT
   DATE(submission_timestamp) AS happened_at,
   recommendation_id,
   tile_id,
-  position,
+  coalesce(safe_cast(position as int), -1) as position,
   SUM(CASE
       WHEN event_name = 'impression' THEN 1
     ELSE

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -46,8 +46,8 @@ SELECT
   DATE(submission_timestamp) AS happened_at,
   recommendation_id,
   tile_id,
-  position,
-  'CARDGRID' AS SOURCE,
+  coalesce(safe_cast(position as int), -1) as position,
+  'CARDGRID' AS source,
   locale,
   country,
   SUM(CASE


### PR DESCRIPTION
the hourly glean extract can send a string as the position value as an edge case.  
adding a safe_cast to set strings to -1

## References

https://mozilla-hub.atlassian.net/browse/DENG-3735

https://mozilla.slack.com/archives/C05EBRU3V1U/p1715636441201559


