### PR TITLE
fix: [MC-1125] Fix missing engagement for Thompson sampling

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.8"
+version = "0.14.9"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/new_tab_recommendations/aggregate_engagement_flow.py
+++ b/data-products/src/new_tab_recommendations/aggregate_engagement_flow.py
@@ -62,40 +62,40 @@ DECLARE max_ts timestamp;
 create schema if not exists `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}`;
 
 -- table if not exists
-create table if not exists `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country` as (
+create table if not exists `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country_v2` as (
       SELECT
         document_id,
         submission_timestamp,
         event.name AS event_name,
-        extra.value AS recommendation_id,
+        extra.value AS tile_id,
         normalized_country_code,
         current_timestamp() AS _loaded_at
       FROM `moz-fx-data-shared-prod.firefox_desktop.newtab_live` AS e
       CROSS JOIN UNNEST(e.events) AS event
-      CROSS JOIN UNNEST(event.extra) AS extra ON extra.key = 'recommendation_id'
+      CROSS JOIN UNNEST(event.extra) AS extra ON extra.key = 'tile_id'
       WHERE
         submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
         AND 1 = 2
 );
 -- get max submission timestamp from table
 SET max_ts = (select coalesce(max(submission_timestamp), TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)) as max_ts
-from `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country`);
+from `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country_v2`);
 
 -- insert new records
-insert into `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country`
+insert into `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country_v2`
       SELECT
         document_id,
         submission_timestamp,
         event.name AS event_name,
-        extra.value AS recommendation_id,
+        extra.value AS tile_id,
         normalized_country_code,
         current_timestamp() AS _loaded_at
       FROM `moz-fx-data-shared-prod.firefox_desktop.newtab_live` AS e
       CROSS JOIN UNNEST(e.events) AS event
-      CROSS JOIN UNNEST(event.extra) AS extra ON extra.key = 'recommendation_id'
+      CROSS JOIN UNNEST(event.extra) AS extra ON extra.key = 'tile_id'
       WHERE
         submission_timestamp > max_ts
-        AND app_build >= '20231116134553' -- Fx 120 was the first build to emit recommendation_id
+        AND app_build >= '20231116134553' -- Fx 120 was the first build to emit tile_id
         AND event.category = 'pocket'
         AND event.name in ('click', 'impression');
 """
@@ -105,14 +105,14 @@ def get_clean_telemetry_sql(country: bool = None):
     return f"""
     -- get aggregations
       SELECT
-          recommendation_id as CORPUS_RECOMMENDATION_ID,
+          tile_id as TILE_ID,
           FORMAT_DATETIME("%Y-%m-%dT%H:%M:%SZ", MAX(submission_timestamp)) as UPDATED_AT,  -- Feature Store requires ISO 8601 time format
           APPROX_COUNT_DISTINCT(IF(event_name = 'impression', document_id, NULL)) AS TRAILING_1_DAY_IMPRESSIONS,
           APPROX_COUNT_DISTINCT(IF(event_name = 'click', document_id, NULL)) AS TRAILING_1_DAY_OPENS
-      FROM `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country`
+      FROM `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country_v2`
       where submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
       {"and normalized_country_code = @country" if country else ""}
-      GROUP BY recommendation_id
+      GROUP BY tile_id
       ORDER BY TRAILING_1_DAY_IMPRESSIONS DESC
       LIMIT 16384; -- Limit to Snowflake's max list size. Can be removed once we don't join across BQ/Snowflake anymore."""  # noqa: E501
 
@@ -154,10 +154,17 @@ class TelemetrySource(NamedTuple):
 
 """
 Glean events have a 'recommendation id' (a.k.a. 'corpus recommendation id'), 
-which is distinct for each server-side
-event when content is recommended. Activity Stream uses the older 'tile id', 
-which is distinct for each time content is
+which is distinct for each server-side event when content is recommended, as
+well as a 'tile_id'.
+Activity Stream uses the older 'tile id', which is distinct for each time content is
 scheduled, and cannot be traced back to a single server-side recommendation event.
+
+Glean can be joined on TILE_ID or CORPUS_RECOMMENDATION_ID.
+On 2024-05-28 we switched the join column back to TILE_ID because
+too many CORPUS_RECOMMENDATION_ID values were generated each day
+to join the tables in memory using a single WHERE IN query.
+TILE_ID is unique by the content and scheduled date, and has far
+fewer distinct values each day.
 
 The ability to trace back to server-side events improves observability 
 and enables experiments with rankers.
@@ -165,17 +172,15 @@ and enables experiments with rankers.
 telemetry_sources: list[TelemetrySource] = [
     TelemetrySource(
         EXPORT_GLEAN_TELEMETRY_SQL,
-        get_export_corpus_item_keys_sql(join_column_name="CORPUS_RECOMMENDATION_ID"),
-        "CORPUS_RECOMMENDATION_ID",
-    ),  # Glean is joined on recommendation UUID.
+        get_export_corpus_item_keys_sql(join_column_name="TILE_ID"),
+        "TILE_ID",
+    ),
     TelemetrySource(
         EXPORT_GLEAN_COUNTRY_TELEMETRY_SQL,
-        get_export_corpus_item_keys_sql(
-            join_column_name="CORPUS_RECOMMENDATION_ID", country="CA"
-        ),
-        "CORPUS_RECOMMENDATION_ID",
+        get_export_corpus_item_keys_sql(join_column_name="TILE_ID", country="CA"),
+        "TILE_ID",
         [("country", "STRING", "CA")],
-    ),  # Glean is joined on recommendation UUID.
+    ),
     TelemetrySource(
         EXPORT_ACTIVITY_STREAM_TELEMETRY_SQL,
         get_export_corpus_item_keys_sql(join_column_name="TILE_ID"),
@@ -205,6 +210,8 @@ async def export_telemetry_by_corpus_item_id(
         query_params=export_telemetry_params,
         to_dataframe=True,
     )
+    df_telemetry[join_column_name] = df_telemetry[join_column_name].astype(str)
+
     corpus_item_keys_records = await snowflake_query(
         snowflake_connector=MozSnowflakeConnector(),
         query=export_corpus_item_keys_sql,
@@ -213,11 +220,14 @@ async def export_telemetry_by_corpus_item_id(
     )
 
     df_corpus_item_keys = pd.DataFrame(corpus_item_keys_records)
+    df_corpus_item_keys[join_column_name] = df_corpus_item_keys[
+        join_column_name
+    ].astype(str)
+
     # Combine the BigQuery and Snowflake results on TILE_ID.
     df_telemetry = pd.merge(df_telemetry, df_corpus_item_keys)
 
-    # Drop TILE_ID or CORPUS_RECOMMENDATION_ID after merging,
-    # to match the dataframe columns with the feature group.
+    # Drop TILE_ID after merging, to match the dataframe columns with the feature group.
     return df_telemetry.drop(columns=[join_column_name])
 
 
@@ -251,14 +261,19 @@ async def aggregate_engagement():
         pd.concat(all_dataframes)
         .groupby(
             [
-                "UPDATED_AT",
                 "KEY",
                 "RECOMMENDATION_SURFACE_ID",
                 "CORPUS_SLATE_CONFIGURATION_ID",
                 "CORPUS_ITEM_ID",
             ]
         )
-        .sum()
+        .agg(
+            {
+                "UPDATED_AT": "max",
+                "TRAILING_1_DAY_IMPRESSIONS": "sum",
+                "TRAILING_1_DAY_OPENS": "sum",
+            }
+        )
         .reset_index()
     )
 

--- a/data-products/tests/new_tab_recommendations/test_aggregate_engagement_flow.py
+++ b/data-products/tests/new_tab_recommendations/test_aggregate_engagement_flow.py
@@ -18,7 +18,7 @@ def mock_bigquery_snowflake_data(request):
         join_column_name = "TILE_ID"
         ids = [4139552719614857, 2352534083175407, 3984239929814862]
     elif data_type == "glean":
-        join_column_name = "CORPUS_RECOMMENDATION_ID"
+        join_column_name = "TILE_ID"
         ids = [
             "f7c76d5f-6df4-4588-9028-22a88ce6927c",
             "9a1dfb60-072d-49e2-83b1-4c99f59fb0dc",
@@ -128,7 +128,7 @@ async def test_aggregate_engagement(mock_bigquery_snowflake_data):
             ),
             pd.DataFrame(
                 {
-                    "UPDATED_AT": ["2", "3"],
+                    "UPDATED_AT": ["3", "3"],
                     "TRAILING_1_DAY_IMPRESSIONS": [300, 400],
                     "TRAILING_1_DAY_OPENS": [3, 4],
                     "KEY": ["2", "3"],
@@ -155,17 +155,19 @@ async def test_aggregate_engagement(mock_bigquery_snowflake_data):
             # Assert that dataframe_to_feature_group is called with the expected DataFrame
             assert mock_dataframe_to_feature_group.call_count == 1  # type: ignore
 
+            df_result = mock_dataframe_to_feature_group.call_args.kwargs["dataframe"]
+
             pd.testing.assert_frame_equal(
-                mock_dataframe_to_feature_group.call_args.kwargs["dataframe"],  # type: ignore  # noqa: E501
+                df_result,  # type: ignore  # noqa: E501
                 pd.DataFrame(
                     {
-                        "UPDATED_AT": ["1", "2", "3", "4", "5"],
-                        "KEY": ["1", "2", "3", "1/CA", "2/CA"],
+                        "KEY": ["1", "1/CA", "2", "2/CA", "3"],
                         "RECOMMENDATION_SURFACE_ID": ["r1", "r1", "r1", "r1", "r1"],
                         "CORPUS_SLATE_CONFIGURATION_ID": ["s1", "s1", "s1", "s1", "s1"],
-                        "CORPUS_ITEM_ID": ["foo1", "foo2", "foo3", "foo1", "foo2"],
-                        "TRAILING_1_DAY_IMPRESSIONS": [100, 500, 400, 100, 200],
-                        "TRAILING_1_DAY_OPENS": [1, 5, 4, 1, 2],
+                        "CORPUS_ITEM_ID": ["foo1", "foo1", "foo2", "foo2", "foo3"],
+                        "UPDATED_AT": ["1", "4", "3", "5", "3"],
+                        "TRAILING_1_DAY_IMPRESSIONS": [100, 100, 500, 200, 400],
+                        "TRAILING_1_DAY_OPENS": [1, 1, 5, 2, 4],
                         "TRAILING_7_DAY_IMPRESSIONS": [0, 0, 0, 0, 0],
                         "TRAILING_7_DAY_OPENS": [0, 0, 0, 0, 0],
                         "TRAILING_14_DAY_IMPRESSIONS": [0, 0, 0, 0, 0],


### PR DESCRIPTION
## Goal
[MC-1125](https://mozilla-hub.atlassian.net/browse/MC-1125) The aggregate engagement metrics in the Sagemaker Feature Store should closely match the source data in BigQuery.

I've identified two reasons why that's not currently the case:
1. Data from Activity Stream and BigQuery was not correctly merged. `UPDATED_AT` does not match exactly between Activity Stream and Glean, leading to separate rows for Activity Stream and BigQuery instead of opens and impressions being summed. The Feature Group API would return only the row with the latest `UPDATED_AT` timestamp.
2. Aggregating on `CORPUS_RECOMMENDATION_ID` resulted in too many rows getting dropped due to the `LIMIT 16384`, and only a fraction of engagement data making it in.

## How to test this is working
- [x] Push this flow to dev-v2 and run the development deployment in Prefect.
- [x] Look up the `tile_id` and `approved_corpus_item_external_id` item scheduled for today or yesterday in Snowflake.
  - Result: tile id `1972237907509487`, corpus item id `07d8c971-e668-4af6-b0ca-5784abcfdb7e`
- [x] Query the [engagement_by_tile_id.sql](https://github.com/Pocket/data-flows/files/15439770/engagement_by_tile_id.txt) for this tile_id for the last day.
  - Result: 924450 impressions, 2137 opens
- [x] Query the record from the _development_ Feature Store: 
   ```shell
   aws sagemaker-featurestore-runtime get-record \
     --feature-group-name development-corpus-engagement-v1 \
     --record-identifier-value-as-string "NEW_TAB_EN_US/edc5571f-7adb-537a-afd8-5612155d54da/07d8c971-e668-4af6-b0ca-5784abcfdb7e"
   ```
  - Result: 922634 impressions, 2170 opens
- [x] Query the record from the _production_ Feature Store: 
   ```shell
   aws sagemaker-featurestore-runtime get-record \
     --feature-group-name development-corpus-engagement-v1 \
     --record-identifier-value-as-string "NEW_TAB_EN_US/edc5571f-7adb-537a-afd8-5612155d54da/07d8c971-e668-4af6-b0ca-5784abcfdb7e"
   ```
  - Result: 26254 impressions, 55 opens

Expectation:
- [x] The development Feature Store metrics approximately matches the BigQuery metrics.

## Deployment steps
- [ ] Merge and run the flow
- [ ] Delete the old BigQuery tables `pocket_user_events` and `pocket_user_events_by_country`

## References

* [Slack thread](https://mozilla.slack.com/archives/C05MEMLP943/p1716504352781039)


[MC-1125]: https://mozilla-hub.atlassian.net/browse/MC-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ