### PR TITLE
fix(labeled-collections): ensuring that the stories in collection slates always have a topic and publisher

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -250,7 +250,7 @@ jobs:
                 condition: << parameters.use_deploy_cli >>
                 steps:
                   - setup_remote_docker:
-                      version: 20.10.18
+                      version: docker24
                   - when:
                       condition: << parameters.validate_build_only >>
                       steps:
@@ -282,7 +282,7 @@ jobs:
           steps:
             - git_checkout
             - setup_remote_docker:
-                version: 20.10.18
+                version: docker24
             - run:
                 command: |
                   docker build --platform linux/amd64 -t prefect-agent -f agent/Dockerfile .

--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.7"
+version = "0.14.8"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/recommendation_api/sql/labeled_collection_stories.sql
+++ b/data-products/src/recommendation_api/sql/labeled_collection_stories.sql
@@ -18,3 +18,4 @@ select
 from  analytics.dbt.approved_corpus_items as aci
 inner join labeled_stories as ls on ls.url = aci.url
 where aci.approved_corpus_item_external_id != 'c931d2f5-0205-48f1-a773-dd0e682977b1'   -- See #incidents on 2023-03-21
+and TOPIC is not null and PUBLISHER is not null -- Recommendations need to always have a topic and publisher


### PR DESCRIPTION
## Goal

Make it so the corpus slate job does not fail if a topic or publisher is missing by not returning those items.
