### PR TITLE
fix(article_streaming): updating the delimiter and escaping logic to prevent errors

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.10"
+version = "0.14.11"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -113,7 +113,11 @@ copy into {DB}.{SCHEMA}.ARTICLE_CONTENT_V2
 (resolved_id, html, text, text_md5)
 from %(uri)s
 storage_integration = {STORAGE_INTEGRATION}
-file_format = (type = 'CSV', skip_header=1, FIELD_OPTIONALLY_ENCLOSED_BY='"')
+file_format = (type = 'CSV', 
+skip_header=1, 
+FIELD_OPTIONALLY_ENCLOSED_BY='"', 
+FIELD_DELIMITER = '|', 
+ESCAPE = '\\\\')
 on_error=ABORT_STATEMENT;
 """
 
@@ -279,7 +283,7 @@ def create_chunks(dfs: list[pd.DataFrame]) -> list[tuple]:
     def prep_object_data(df: pd.DataFrame) -> BytesIO:
         csv_buffer = BytesIO()
         with gzip.GzipFile(mode="w", fileobj=csv_buffer, compresslevel=1) as gz_file:
-            df.to_csv(gz_file, index=False)  # type: ignore
+            df.to_csv(gz_file, index=False, sep="|", escapechar="\\")  # type: ignore
 
         return csv_buffer
 


### PR DESCRIPTION

Error is pasted into the JIRA ticket.  Changing the delimiter to '|' for less chance of conflict.  Also adding proper '\' escaping for csv file upload.


## References

JIRA ticket:
https://mozilla-hub.atlassian.net/browse/DENG-4086
