### PR TITLE
fix(glean_extraction): adding proper filters to exclude suspicious click activity from numbers

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.11"
+version = "0.14.12"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_daily/glean_firefox_new_tab_daily_unique_engagement_by_feed/data.sql
@@ -10,7 +10,12 @@
 WITH
   deduplicated_pings AS (
   SELECT
-    *
+    submission_timestamp,
+    document_id,
+    normalized_country_code,
+    client_info,
+    events,
+    metrics
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1`
   WHERE
@@ -21,6 +26,7 @@ WITH
       submission_timestamp DESC) = 1 ),
   flattened_pocket_events AS (
   SELECT
+    document_id,
     DATE(submission_timestamp) AS happened_at,
     CASE
       WHEN ( normalized_country_code IN ('US', 'CA') AND metrics.string.newtab_locale IN ('en-CA', 'en-GB', 'en-US') ) THEN 'NEW_TAB_EN_US'
@@ -48,7 +54,8 @@ WITH
         'is_sponsored') AS boolean) AS is_sponsored,
     metrics.boolean.pocket_enabled = TRUE AS pocket_enabled,
     metrics.boolean.pocket_sponsored_stories_enabled = TRUE AS pocket_sponsored_stories_enabled,
-    client_info.client_id AS client_id
+    client_info.client_id AS client_id,
+    COUNT(1) OVER (PARTITION BY document_id, e.name) as user_event_count
   FROM
     deduplicated_pings,
     UNNEST(events) AS e
@@ -119,6 +126,7 @@ SELECT
     ) AS users_clicking_spocs_count,
 FROM
   flattened_pocket_events
+WHERE NOT (user_event_count > 50 AND event_name = 'click')
 GROUP BY
   1,
   2

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -7,7 +7,11 @@
 WITH
   deduplicated_pings AS (
   SELECT
-    *
+    submission_timestamp,
+    document_id,
+    normalized_country_code,
+    client_info,
+    events
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_live.newtab_v1` {{helpers.legacy_rolling_24_hours_filter()}} QUALIFY ROW_NUMBER() OVER (PARTITION BY DATE(submission_timestamp),
       document_id
@@ -15,6 +19,7 @@ WITH
       submission_timestamp DESC) = 1 ),
   flattened_pocket_events AS (
   SELECT
+    document_id,
     submission_timestamp,
     e.name AS event_name,
     mozfun.map.get_key(e.extra,
@@ -22,7 +27,8 @@ WITH
     mozfun.map.get_key(e.extra,
       'tile_id') AS tile_id,
     mozfun.map.get_key(e.extra,
-      'position') AS position
+      'position') AS position,
+  COUNT(1) OVER (PARTITION BY document_id, e.name) as user_event_count
   FROM
     deduplicated_pings,
     UNNEST(events) AS e
@@ -72,6 +78,8 @@ SELECT
 FROM
   flattened_pocket_events
 WHERE CAST(tile_id AS STRING) not like '18408385020159%'
+-- Exclude suspicious activity
+AND NOT (user_event_count > 50 AND event_name = 'click')
 GROUP BY
   1,
   2,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -15,6 +15,7 @@ WITH
       submission_timestamp DESC) = 1 ),
   flattened_pocket_events AS (
   SELECT
+    document_id,
     submission_timestamp,
     e.name AS event_name,
     mozfun.map.get_key(e.extra,
@@ -24,7 +25,8 @@ WITH
     mozfun.map.get_key(e.extra,
       'position') AS position,
     metrics.string.newtab_locale AS locale,
-    normalized_country_code AS country
+    normalized_country_code AS country,
+  COUNT(1) OVER (PARTITION BY document_id, e.name) as user_event_count
   FROM
     deduplicated_pings,
     UNNEST(events) AS e
@@ -77,6 +79,7 @@ SELECT
 FROM
   flattened_pocket_events
 WHERE CAST(tile_id AS STRING) not like '18408385020159%'
+AND NOT (user_event_count > 50 AND event_name = 'click')
 GROUP BY
   1,
   2,


### PR DESCRIPTION
This applying fix made to ads reporting to pocket glean data extraction to prevent over-reporting on the mode reports.

https://github.com/mozilla/private-bigquery-etl/pull/421

This will require a backfill.

## References

JIRA ticket:
https://mozilla-hub.atlassian.net/browse/AD-324