### PR TITLE
fix: apply timezone filtering to android recs

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.15"
+version = "0.14.16"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/recommendation_api/sql/recommended_by_recency.sql
+++ b/data-products/src/recommendation_api/sql/recommended_by_recency.sql
@@ -11,7 +11,9 @@ WITH recently_updated_items as (
         approved_corpus_item_external_id as "ID",
         topic as "TOPIC",
         publisher as "PUBLISHER",
-        reviewed_corpus_item_updated_at as "REVIEW_TIME"
+        reviewed_corpus_item_updated_at as "REVIEW_TIME",
+        -- prefer scheduled items over approved items
+        2 as "RELEVANCE"
     FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
     WHERE CORPUS_REVIEW_STATUS = 'recommendation'
     -- only pull corpus items that were reviewed before the max_timestamp
@@ -27,7 +29,9 @@ recently_scheduled_items as (
         approved_corpus_item_external_id as "ID",
         topic as "TOPIC",
         publisher as "PUBLISHER",
-        scheduled_corpus_item_scheduled_at as "REVIEW_TIME"
+        scheduled_corpus_item_scheduled_at as "REVIEW_TIME",
+        -- prefer scheduled items over approved items
+        1 as "RELEVANCE"
     FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
     -- only pull scheduled items that are scheduled before the max_timestamp
     WHERE SCHEDULED_CORPUS_ITEM_SCHEDULED_AT < $max_timestamp
@@ -54,4 +58,4 @@ SELECT
     TOPIC,
     PUBLISHER
 FROM deduped
-QUALIFY row_number() OVER (PARTITION BY TOPIC ORDER BY REVIEW_TIME DESC) <= %(N_RECS_PER_TOPIC)s;
+QUALIFY row_number() OVER (PARTITION BY TOPIC ORDER BY RELEVANCE, REVIEW_TIME DESC) <= %(N_RECS_PER_TOPIC)s;

--- a/data-products/src/recommendation_api/sql/recommended_by_recency.sql
+++ b/data-products/src/recommendation_api/sql/recommended_by_recency.sql
@@ -1,3 +1,11 @@
+-- this script is only called for NEW_TAB_EN_US, so we can hard-code the timezone and offset below
+
+-- get the current timestamp in EST
+SET max_timestamp = CONVERT_TIMEZONE('UTC', 'America/New_York', current_timestamp());
+
+-- adjust for 3am offset for en-US new tab content rollover
+SET max_timestamp = dateadd(hour, -3, $max_timestamp);
+
 WITH recently_updated_items as (
     SELECT
         approved_corpus_item_external_id as "ID",
@@ -6,6 +14,8 @@ WITH recently_updated_items as (
         reviewed_corpus_item_updated_at as "REVIEW_TIME"
     FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
     WHERE CORPUS_REVIEW_STATUS = 'recommendation'
+    -- only pull corpus items that were reviewed before the max_timestamp
+    AND REVIEWED_CORPUS_ITEM_CREATED_AT < $max_timestamp
     AND SCHEDULED_SURFACE_ID = %(SCHEDULED_SURFACE_ID)s
     AND NOT is_syndicated
     AND NOT is_collection
@@ -19,8 +29,8 @@ recently_scheduled_items as (
         publisher as "PUBLISHER",
         scheduled_corpus_item_scheduled_at as "REVIEW_TIME"
     FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
-    WHERE SCHEDULED_CORPUS_ITEM_SCHEDULED_AT < current_timestamp()
-    AND CORPUS_ITEM_LOADED_FROM = 'MANUAL'  -- should this be removed?
+    -- only pull scheduled items that are scheduled before the max_timestamp
+    WHERE SCHEDULED_CORPUS_ITEM_SCHEDULED_AT < $max_timestamp
     AND SCHEDULED_SURFACE_ID = %(SCHEDULED_SURFACE_ID)s
     AND NOT is_syndicated
     AND NOT is_collection


### PR DESCRIPTION
## The Problem

due to timezone issues, android home is displaying items before they should be seen, and likely before curators have had a chance to look at them (for ML scheduled items). 

## Goal

apply timezone filtering to both the reviewed items query and the scheduled items query. the intent of the fix is to only return items that have been approved and/or scheduled before the current timestamp in EST minus 3 hours. 

this script is only ever called with `NEW_TAB_EN_US` as the surface, and (afaik!) is only used to generate slates for android home recommendations.

- remove 'MANUAL' restriction on corpus items (not needed now that we have timezone filtering)

## Implementation Decisions
 
hard-code for `NEW_TAB_EN_US` as that's the only surface against which this script is run (as far as i can tell - see the config [here](https://github.com/Pocket/data-flows/blob/main-v2/data-products/src/shared/models/corpus_candidate_set_configs.py#L71-L76)).

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/MC-1239