### PR TITLE
fix(sql): sql statements that are used for loading data into snowflake from BQ need to be protected from tile_ids as strings

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.14.14"
+version = "0.14.15"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/new_tab_recommendations/aggregate_engagement_flow.py
+++ b/data-products/src/new_tab_recommendations/aggregate_engagement_flow.py
@@ -111,6 +111,7 @@ def get_clean_telemetry_sql(country: bool = None):
           APPROX_COUNT_DISTINCT(IF(event_name = 'click', document_id, NULL)) AS TRAILING_1_DAY_OPENS
       FROM `moz-fx-mozsocial-dw-{NEW_TAB_REC_GCP_PROJECT_ENV}.{NEW_TAB_REC_DATASET}.pocket_user_events_by_country_v2`
       where submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+      and safe_cast(tile_id as int) is not null
       {"and normalized_country_code = @country" if country else ""}
       GROUP BY tile_id
       ORDER BY TRAILING_1_DAY_IMPRESSIONS DESC

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -63,7 +63,7 @@ WITH
 SELECT
   DATE(submission_timestamp) AS happened_at,
   recommendation_id,
-  tile_id,
+  coalesce(safe_cast(tile_id as int), -1) as tile_id,
   coalesce(safe_cast(position as int), -1) as position,
   SUM(CASE
       WHEN event_name = 'impression' THEN 1
@@ -91,9 +91,8 @@ SELECT
     ) AS dismiss_count
 FROM
   flattened_pocket_events
-WHERE CAST(tile_id AS STRING) not like '18408385020159%'
 -- Exclude suspicious activity
-AND NOT (user_event_count > 50 AND event_name = 'click')
+WHERE NOT (user_event_count > 50 AND event_name = 'click')
 GROUP BY
   1,
   2,

--- a/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -61,7 +61,7 @@ WITH
 SELECT
   DATE(submission_timestamp) AS happened_at,
   recommendation_id,
-  tile_id,
+  coalesce(safe_cast(tile_id as int), -1) as tile_id,
   coalesce(safe_cast(position as int), -1) as position,
   'CARDGRID' AS source,
   locale,
@@ -92,8 +92,7 @@ SELECT
     ) AS dismiss_count
 FROM
   flattened_pocket_events
-WHERE CAST(tile_id AS STRING) not like '18408385020159%'
-AND NOT (user_event_count > 50 AND event_name = 'click')
+WHERE NOT (user_event_count > 50 AND event_name = 'click')
 GROUP BY
   1,
   2,


### PR DESCRIPTION
`data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql` and 
`data-products/src/sql_etl/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql`

will safe_cast on tile_id and set bad ones to -1, just like we did with position


`data-products/src/new_tab_recommendations/aggregate_engagement_flow.py`

this will filter out tile_ids that are not ints

https://mozilla-hub.atlassian.net/browse/AD-426

