### PR TITLE
feat(locales): adding in new candidate set locales

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.15.2"
+version = "0.15.3"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/recommendation_api/corpus_candidate_sets_flow.py
+++ b/data-products/src/recommendation_api/corpus_candidate_sets_flow.py
@@ -35,6 +35,42 @@ SELECT
     corpus_topic_id as "CORPUS_TOPIC_ID",
     'NEW_TAB_DE_DE' as "SCHEDULED_SURFACE_ID"
 FROM analytics.dbt.static_corpus_candidate_set_topics
+
+UNION ALL
+
+SELECT
+    en_gb_curated_corpus_candidate_set_id as "CORPUS_CANDIDATE_SET_ID",
+    concat('en_gb/', LOWER(corpus_topic_id)) as "NAME",
+    corpus_topic_id as "CORPUS_TOPIC_ID",
+    'NEW_TAB_EN_GB' as "SCHEDULED_SURFACE_ID"
+FROM analytics.dbt.static_corpus_candidate_set_topics
+
+UNION ALL
+
+SELECT
+    fr_fr_curated_corpus_candidate_set_id as "CORPUS_CANDIDATE_SET_ID",
+    concat('fr_fr/', LOWER(corpus_topic_id)) as "NAME",
+    corpus_topic_id as "CORPUS_TOPIC_ID",
+    'NEW_TAB_FR_FR' as "SCHEDULED_SURFACE_ID"
+FROM analytics.dbt.static_corpus_candidate_set_topics
+
+UNION ALL
+
+SELECT
+    it_it_curated_corpus_candidate_set_id as "CORPUS_CANDIDATE_SET_ID",
+    concat('it_it/', LOWER(corpus_topic_id)) as "NAME",
+    corpus_topic_id as "CORPUS_TOPIC_ID",
+    'NEW_TAB_IT_IT' as "SCHEDULED_SURFACE_ID"
+FROM analytics.dbt.static_corpus_candidate_set_topics
+
+UNION ALL
+
+SELECT
+    es_es_curated_corpus_candidate_set_id as "CORPUS_CANDIDATE_SET_ID",
+    concat('es_es/', LOWER(corpus_topic_id)) as "NAME",
+    corpus_topic_id as "CORPUS_TOPIC_ID",
+    'NEW_TAB_ES_ES' as "SCHEDULED_SURFACE_ID"
+FROM analytics.dbt.static_corpus_candidate_set_topics
 """
 
 

--- a/data-products/src/recommendation_api/sql/life_hacks.sql
+++ b/data-products/src/recommendation_api/sql/life_hacks.sql
@@ -6,7 +6,7 @@ WITH recently_updated_items as (
         reviewed_corpus_item_updated_at as "REVIEW_TIME"
     FROM "ANALYTICS"."DBT"."APPROVED_CORPUS_ITEMS"
     WHERE CORPUS_REVIEW_STATUS = 'recommendation'
-    AND SCHEDULED_SURFACE_ID = 'NEW_TAB_EN_US'
+    AND SCHEDULED_SURFACE_ID =  %(SCHEDULED_SURFACE_ID)s
     AND NOT is_syndicated
     AND NOT is_collection
 ),
@@ -20,7 +20,7 @@ recently_scheduled_items as (
     FROM "ANALYTICS"."DBT"."SCHEDULED_CORPUS_ITEMS"
     WHERE SCHEDULED_CORPUS_ITEM_SCHEDULED_AT < current_timestamp()
     AND CORPUS_ITEM_LOADED_FROM = 'MANUAL'  -- should this be removed?
-    AND SCHEDULED_SURFACE_ID = 'NEW_TAB_EN_US'
+    AND SCHEDULED_SURFACE_ID =  %(SCHEDULED_SURFACE_ID)s
     AND NOT is_syndicated
     AND NOT is_collection
 )

--- a/data-products/src/shared/models/corpus_candidate_set_configs.py
+++ b/data-products/src/shared/models/corpus_candidate_set_configs.py
@@ -43,6 +43,82 @@ static_candidate_set_configs = [
         query_filename="life_hacks.sql",
         query_params={
             "MAX_AGE_DAYS": 30,
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_US",
+            "CORPUS_TOPIC_LIST": [
+                "SELF_IMPROVEMENT",
+                "CAREER",
+                "HEALTH_FITNESS",
+                "PERSONAL_FINANCE",
+            ],
+        },
+    ),
+    CorpusCandidateSetConfig(
+        id="1b086a7e-7f49-416b-8fd6-254d84001f7c",
+        name="de_de/life_hacks",
+        query_filename="life_hacks.sql",
+        query_params={
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_DE_DE",
+            "MAX_AGE_DAYS": 30,
+            "CORPUS_TOPIC_LIST": [
+                "SELF_IMPROVEMENT",
+                "CAREER",
+                "HEALTH_FITNESS",
+                "PERSONAL_FINANCE",
+            ],
+        },
+    ),
+    CorpusCandidateSetConfig(
+        id="b5179696-4516-4d2f-b42b-b0424e3e4d18",
+        name="en_gb/life_hacks",
+        query_filename="life_hacks.sql",
+        query_params={
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_GB",
+            "MAX_AGE_DAYS": 30,
+            "CORPUS_TOPIC_LIST": [
+                "SELF_IMPROVEMENT",
+                "CAREER",
+                "HEALTH_FITNESS",
+                "PERSONAL_FINANCE",
+            ],
+        },
+    ),
+    CorpusCandidateSetConfig(
+        id="c082fb1f-bec9-45e5-b119-e658cc29366c",
+        name="fr_fr/life_hacks",
+        query_filename="life_hacks.sql",
+        query_params={
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_FR_FR",
+            "MAX_AGE_DAYS": 30,
+            "CORPUS_TOPIC_LIST": [
+                "SELF_IMPROVEMENT",
+                "CAREER",
+                "HEALTH_FITNESS",
+                "PERSONAL_FINANCE",
+            ],
+        },
+    ),
+    CorpusCandidateSetConfig(
+        id="22312367-36a5-4ceb-bce6-7fea7e83759b",
+        name="it_it/life_hacks",
+        query_filename="life_hacks.sql",
+        query_params={
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT",
+            "MAX_AGE_DAYS": 30,
+            "CORPUS_TOPIC_LIST": [
+                "SELF_IMPROVEMENT",
+                "CAREER",
+                "HEALTH_FITNESS",
+                "PERSONAL_FINANCE",
+            ],
+        },
+    ),
+    CorpusCandidateSetConfig(
+        id="c62e86b4-8d88-4036-80e3-00394323946f",
+        name="es_es/life_hacks",
+        query_filename="life_hacks.sql",
+        query_params={
+            "SCHEDULED_SURFACE_ID": "NEW_TAB_ES_ES",
+            "MAX_AGE_DAYS": 30,
             "CORPUS_TOPIC_LIST": [
                 "SELF_IMPROVEMENT",
                 "CAREER",
@@ -68,6 +144,30 @@ static_candidate_set_configs = [
         name="de_de/new_tab_not_syndicated_or_collection",
         query_filename="scheduled_not_syndicated_or_collection.sql",
         query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_DE_DE"},
+    ),
+    CorpusCandidateSetConfig(
+        id="43637b16-1572-4f9b-ba5b-cb686d665633",
+        name="en_gb/new_tab_not_syndicated_or_collection",
+        query_filename="scheduled_not_syndicated_or_collection.sql",
+        query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_GB"},
+    ),
+    CorpusCandidateSetConfig(
+        id="70c4dffe-dd0b-4d97-ba76-69778b921b21",
+        name="fr_fr/new_tab_not_syndicated_or_collection",
+        query_filename="scheduled_not_syndicated_or_collection.sql",
+        query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_FR_FR"},
+    ),
+    CorpusCandidateSetConfig(
+        id="bbf0dccb-d1a2-45bd-a0fd-7d8b8f61bb7a",
+        name="it_it/new_tab_not_syndicated_or_collection",
+        query_filename="scheduled_not_syndicated_or_collection.sql",
+        query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT"},
+    ),
+    CorpusCandidateSetConfig(
+        id="62b47b84-c32b-4798-8599-e75d61f8c21b",
+        name="es_es/new_tab_not_syndicated_or_collection",
+        query_filename="scheduled_not_syndicated_or_collection.sql",
+        query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT"},
     ),
     CorpusCandidateSetConfig(
         id="2066c835-a940-45ec-b1f7-267457d9e0a2",

--- a/data-products/src/shared/models/corpus_candidate_set_configs.py
+++ b/data-products/src/shared/models/corpus_candidate_set_configs.py
@@ -167,7 +167,7 @@ static_candidate_set_configs = [
         id="62b47b84-c32b-4798-8599-e75d61f8c21b",
         name="es_es/new_tab_not_syndicated_or_collection",
         query_filename="scheduled_not_syndicated_or_collection.sql",
-        query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT"},
+        query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_ES_ES"},
     ),
     CorpusCandidateSetConfig(
         id="2066c835-a940-45ec-b1f7-267457d9e0a2",

--- a/data-products/tests/recommendation_api/test_corpus_candidate_sets_flow.py
+++ b/data-products/tests/recommendation_api/test_corpus_candidate_sets_flow.py
@@ -98,6 +98,87 @@ async def test_create_all_candidate_set_configs(monkeypatch):
             name="en_us/life_hacks",
             query_filename="life_hacks.sql",
             query_params={
+                "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_US",
+                "MAX_AGE_DAYS": 30,
+                "CORPUS_TOPIC_LIST": [
+                    "SELF_IMPROVEMENT",
+                    "CAREER",
+                    "HEALTH_FITNESS",
+                    "PERSONAL_FINANCE",
+                ],
+            },
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="1b086a7e-7f49-416b-8fd6-254d84001f7c",
+            name="de_de/life_hacks",
+            query_filename="life_hacks.sql",
+            query_params={
+                "SCHEDULED_SURFACE_ID": "NEW_TAB_DE_DE",
+                "MAX_AGE_DAYS": 30,
+                "CORPUS_TOPIC_LIST": [
+                    "SELF_IMPROVEMENT",
+                    "CAREER",
+                    "HEALTH_FITNESS",
+                    "PERSONAL_FINANCE",
+                ],
+            },
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="b5179696-4516-4d2f-b42b-b0424e3e4d18",
+            name="en_gb/life_hacks",
+            query_filename="life_hacks.sql",
+            query_params={
+                "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_GB",
+                "MAX_AGE_DAYS": 30,
+                "CORPUS_TOPIC_LIST": [
+                    "SELF_IMPROVEMENT",
+                    "CAREER",
+                    "HEALTH_FITNESS",
+                    "PERSONAL_FINANCE",
+                ],
+            },
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="c082fb1f-bec9-45e5-b119-e658cc29366c",
+            name="fr_fr/life_hacks",
+            query_filename="life_hacks.sql",
+            query_params={
+                "SCHEDULED_SURFACE_ID": "NEW_TAB_FR_FR",
+                "MAX_AGE_DAYS": 30,
+                "CORPUS_TOPIC_LIST": [
+                    "SELF_IMPROVEMENT",
+                    "CAREER",
+                    "HEALTH_FITNESS",
+                    "PERSONAL_FINANCE",
+                ],
+            },
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="22312367-36a5-4ceb-bce6-7fea7e83759b",
+            name="it_it/life_hacks",
+            query_filename="life_hacks.sql",
+            query_params={
+                "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT",
+                "MAX_AGE_DAYS": 30,
+                "CORPUS_TOPIC_LIST": [
+                    "SELF_IMPROVEMENT",
+                    "CAREER",
+                    "HEALTH_FITNESS",
+                    "PERSONAL_FINANCE",
+                ],
+            },
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="c62e86b4-8d88-4036-80e3-00394323946f",
+            name="es_es/life_hacks",
+            query_filename="life_hacks.sql",
+            query_params={
+                "SCHEDULED_SURFACE_ID": "NEW_TAB_ES_ES",
                 "MAX_AGE_DAYS": 30,
                 "CORPUS_TOPIC_LIST": [
                     "SELF_IMPROVEMENT",
@@ -127,6 +208,34 @@ async def test_create_all_candidate_set_configs(monkeypatch):
             name="de_de/new_tab_not_syndicated_or_collection",
             query_filename="scheduled_not_syndicated_or_collection.sql",
             query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_DE_DE"},
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="43637b16-1572-4f9b-ba5b-cb686d665633",
+            name="en_gb/new_tab_not_syndicated_or_collection",
+            query_filename="scheduled_not_syndicated_or_collection.sql",
+            query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_EN_GB"},
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="70c4dffe-dd0b-4d97-ba76-69778b921b21",
+            name="fr_fr/new_tab_not_syndicated_or_collection",
+            query_filename="scheduled_not_syndicated_or_collection.sql",
+            query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_FR_FR"},
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="bbf0dccb-d1a2-45bd-a0fd-7d8b8f61bb7a",
+            name="it_it/new_tab_not_syndicated_or_collection",
+            query_filename="scheduled_not_syndicated_or_collection.sql",
+            query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT"},
+            is_multiquery=False,
+        ),
+        CorpusCandidateSetConfig(
+            id="62b47b84-c32b-4798-8599-e75d61f8c21b",
+            name="es_es/new_tab_not_syndicated_or_collection",
+            query_filename="scheduled_not_syndicated_or_collection.sql",
+            query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT"},
             is_multiquery=False,
         ),
         CorpusCandidateSetConfig(
@@ -301,4 +410,4 @@ async def test_corpus_candidate_sets(monkeypatch):
 
     await corpus_candidate_sets()
     assert state["sf_call_count"] == 1
-    assert state["load_call_count"] == 14
+    assert state["load_call_count"] == 23

--- a/data-products/tests/recommendation_api/test_corpus_candidate_sets_flow.py
+++ b/data-products/tests/recommendation_api/test_corpus_candidate_sets_flow.py
@@ -235,7 +235,7 @@ async def test_create_all_candidate_set_configs(monkeypatch):
             id="62b47b84-c32b-4798-8599-e75d61f8c21b",
             name="es_es/new_tab_not_syndicated_or_collection",
             query_filename="scheduled_not_syndicated_or_collection.sql",
-            query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_IT_IT"},
+            query_params={"MAX_AGE_DAYS": -3, "SCHEDULED_SURFACE_ID": "NEW_TAB_ES_ES"},
             is_multiquery=False,
         ),
         CorpusCandidateSetConfig(


### PR DESCRIPTION
## Goal

Pocket wants to add in home surfaces for all the locales we are curating content for.

This adds in candidate sets for:
* en-GB
* it-it
* fr-fr
* es-es

These will be used to generate slates like the de-de for Pocket Home
