### PR TITLE
Mc 1500 fix engagement count

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.15.6"
+version = "0.15.7"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -48,6 +48,9 @@ WITH
         'recommendation_id') IS NOT NULL
       OR mozfun.map.get_key(e.extra,
         'tile_id') IS NOT NULL)
+    --filter out records where scheduled corpus item ID is populated to prevent double count
+    AND mozfun.map.get_key(e.extra,
+        'scheduled_corpus_item_id') IS NULL
     --include only data from Firefox 121+
     AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121 )
 SELECT

--- a/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
+++ b/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position/data.sql
@@ -49,6 +49,7 @@ WITH
       OR mozfun.map.get_key(e.extra,
         'tile_id') IS NOT NULL)
     --filter out records where scheduled corpus item ID is populated to prevent double count
+    --for data prior to Firefox 129 release (pre-Merino)
     AND mozfun.map.get_key(e.extra,
         'scheduled_corpus_item_id') IS NULL
     --include only data from Firefox 121+

--- a/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -46,6 +46,9 @@ WITH
         'recommendation_id') IS NOT NULL
       OR mozfun.map.get_key(e.extra,
         'tile_id') IS NOT NULL)
+    --filter out records where scheduled corpus item ID is populated to prevent double count
+    AND mozfun.map.get_key(e.extra,
+        'scheduled_corpus_item_id') IS NULL
     --include only data from Firefox 121+
     AND SAFE_CAST(SPLIT(client_info.app_display_version, '.')[0] AS int64) >= 121 )
 SELECT

--- a/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
+++ b/data-products/src/firefox_newtab/sql/glean_firefox_new_tab_impressions_hourly/glean_firefox_new_tab_daily_engagement_by_tile_id_position_country_locale/data.sql
@@ -47,6 +47,7 @@ WITH
       OR mozfun.map.get_key(e.extra,
         'tile_id') IS NOT NULL)
     --filter out records where scheduled corpus item ID is populated to prevent double count
+    --for data prior to Firefox 129 release (pre-Merino)
     AND mozfun.map.get_key(e.extra,
         'scheduled_corpus_item_id') IS NULL
     --include only data from Firefox 121+


### PR DESCRIPTION
## Goal
What changed? What is the business/product goal?

- We are seeing double engagement counts due to events being calculated twice. These changes filter out records where `scheduled_corpus_item_id` is null to filter out merino data in legacy queries

## References

JIRA ticket:
[MC-1500](https://mozilla-hub.atlassian.net/browse/MC-1500)

![Screenshot 2024-09-12 at 1 28 17 PM](https://github.com/user-attachments/assets/1a02c097-f166-4f5e-9a8e-f3ed1da5e96a)
![Screenshot 2024-09-12 at 1 27 45 PM](https://github.com/user-attachments/assets/dfcb2088-def5-4f1b-9940-5f183ed4cafc)


[MC-1500]: https://mozilla-hub.atlassian.net/browse/MC-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ