### PR TITLE
Remove aws_changes_build job from all CI workflows

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -299,41 +299,41 @@ jobs:
 workflows:
   pr_workflow:
     jobs: 
-      - aws_changes_build:
-          <<: *not_dev_main_stg_v2
-          context: pocket
-          node_env: development
-          runner_resource_class: pocket/default-dev
-          stack_name: prefect-oidc
-          name: terraform plan oidc dev
-      - aws_changes_build:
-          <<: *not_dev_main_stg_v2
-          context: pocket
-          node_env: production
-          runner_resource_class: pocket/default-prod
-          stack_name: prefect-oidc
-          name: terraform plan oidc production
+      # - aws_changes_build:
+      #     <<: *not_dev_main_stg_v2
+      #     context: pocket
+      #     node_env: development
+      #     runner_resource_class: pocket/default-dev
+      #     stack_name: prefect-oidc
+      #     name: terraform plan oidc dev
+      # - aws_changes_build:
+      #     <<: *not_dev_main_stg_v2
+      #     context: pocket
+      #     node_env: production
+      #     runner_resource_class: pocket/default-prod
+      #     stack_name: prefect-oidc
+      #     name: terraform plan oidc production
       - prefect_agent_docker:
           <<: *not_dev_main_stg_v2
           name: prefect agent docker build
-      - aws_changes_build:
-          <<: *not_dev_main_stg_v2
-          context: pocket
-          node_env: development
-          runner_resource_class: pocket/default-dev
-          stack_name: prefect-v2
-          name: terraform plan prefect dev
-          requires:
-            - terraform plan oidc dev
-      - aws_changes_build:
-          <<: *not_dev_main_stg_v2
-          context: pocket
-          node_env: production
-          runner_resource_class: pocket/default-prod
-          stack_name: prefect-v2
-          name: terraform plan prefect production
-          requires:
-            - terraform plan oidc production
+      # - aws_changes_build:
+      #     <<: *not_dev_main_stg_v2
+      #     context: pocket
+      #     node_env: development
+      #     runner_resource_class: pocket/default-dev
+      #     stack_name: prefect-v2
+      #     name: terraform plan prefect dev
+      #     requires:
+      #       - terraform plan oidc dev
+      # - aws_changes_build:
+      #     <<: *not_dev_main_stg_v2
+      #     context: pocket
+      #     node_env: production
+      #     runner_resource_class: pocket/default-prod
+      #     stack_name: prefect-v2
+      #     name: terraform plan prefect production
+      #     requires:
+      #       - terraform plan oidc production
       - common_utils_changes_build:
           <<: *not_dev_main_stg_v2
       - prefect_project_changes:
@@ -347,14 +347,14 @@ workflows:
             - common_utils_changes_build
   dev_workflow:
     jobs: 
-      - aws_changes_build:
-          <<: *only_dev_v2
-          context: pocket
-          node_env: development
-          runner_resource_class: pocket/default-dev
-          stack_name: prefect-oidc
-          apply_stack: true
-          name: terraform apply oidc dev
+      # - aws_changes_build:
+      #     <<: *only_dev_v2
+      #     context: pocket
+      #     node_env: development
+      #     runner_resource_class: pocket/default-dev
+      #     stack_name: prefect-oidc
+      #     apply_stack: true
+      #     name: terraform apply oidc dev
       - prefect_agent_docker:
           <<: *only_dev_v2
           context: pocket-oidc-dev
@@ -362,26 +362,26 @@ workflows:
           name: prefect agent docker push
           requires:
             - terraform apply oidc dev
-      - aws_changes_build:
-          <<: *only_dev_v2
-          context: pocket
-          node_env: development
-          runner_resource_class: pocket/default-dev
-          stack_name: prefect-v2
-          apply_stack: true
-          name: terraform apply prefect dev
-          requires:
-            - prefect agent docker push
+      # - aws_changes_build:
+      #     <<: *only_dev_v2
+      #     context: pocket
+      #     node_env: development
+      #     runner_resource_class: pocket/default-dev
+      #     stack_name: prefect-v2
+      #     apply_stack: true
+      #     name: terraform apply prefect dev
+      #     requires:
+      #       - prefect agent docker push
   main_workflow:
     jobs: 
-      - aws_changes_build:
-          <<: *only_main_v2
-          context: pocket
-          node_env: production
-          runner_resource_class: pocket/default-prod
-          stack_name: prefect-oidc
-          apply_stack: true
-          name: terraform apply oidc production
+      # - aws_changes_build:
+      #     <<: *only_main_v2
+      #     context: pocket
+      #     node_env: production
+      #     runner_resource_class: pocket/default-prod
+      #     stack_name: prefect-oidc
+      #     apply_stack: true
+      #     name: terraform apply oidc production
       - prefect_agent_docker:
           <<: *only_main_v2
           context: pocket-oidc-prod
@@ -389,16 +389,16 @@ workflows:
           name: prefect agent docker push
           requires:
             - terraform apply oidc production
-      - aws_changes_build:
-          <<: *only_main_v2
-          context: pocket
-          node_env: production
-          runner_resource_class: pocket/default-prod
-          stack_name: prefect-v2
-          apply_stack: true
-          name: terraform apply prefect production
-          requires:
-            - prefect agent docker push
+      # - aws_changes_build:
+      #     <<: *only_main_v2
+      #     context: pocket
+      #     node_env: production
+      #     runner_resource_class: pocket/default-prod
+      #     stack_name: prefect-v2
+      #     apply_stack: true
+      #     name: terraform apply prefect production
+      #     requires:
+      #       - prefect agent docker push
       - common_utils_changes_build:
           <<: *only_main_v2
       - prefect_project_changes:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -360,8 +360,8 @@ workflows:
           context: pocket-oidc-dev
           push_image: true
           name: prefect agent docker push
-          requires:
-            - terraform apply oidc dev
+          # requires:
+          #   - terraform apply oidc dev
       # - aws_changes_build:
       #     <<: *only_dev_v2
       #     context: pocket
@@ -387,8 +387,8 @@ workflows:
           context: pocket-oidc-prod
           push_image: true
           name: prefect agent docker push
-          requires:
-            - terraform apply oidc production
+          # requires:
+          #   - terraform apply oidc production
       # - aws_changes_build:
       #     <<: *only_main_v2
       #     context: pocket
@@ -411,7 +411,7 @@ workflows:
           deployment_type: main
           validate_build_only: false
           requires:
-            - terraform apply prefect production
+            # - terraform apply prefect production
             - common_utils_changes_build
   staging_workflow:
     jobs:


### PR DESCRIPTION
## Goal
What changed? What is the business/product goal?

The uses of `aws_changes_build` cannot run anymore due to CircleCI removing support for the self-hosted runner used (see https://mozilla-hub.atlassian.net/browse/DENG-4736 and https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176)

This is causing workflows that include this job to stall out, even if that job would have been a noop. I'm removing this job from the workflows so that we can still deploy changes that do not change our AWS infrastructure. Since this was already broken, this doesn't put this repo in any worse state than before.

## Implementation Decisions
 

## Deployment steps
- [ ] Database migrations?
- [ ] Secrets?
- [ ] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):

## References

