### PR TITLE
Fix: article-text-streaming failed due to newlines between records

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.15.16"
+version = "0.15.17"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -213,7 +213,7 @@ def transform(
     - Adds the transformed text data as a new field to the Dataframe
 
     Args:
-        contents_future (str): s3 object to process
+        contents (str): s3 object to process
         failure_store (list): shared list to track text conversion failures
         key (str): s3 key for contents being processed
         batch_id (int): batch_id for etl run
@@ -250,9 +250,19 @@ def transform(
 
     fileobj = BytesIO(contents)
     with gzip.GzipFile(fileobj=fileobj) as gzipfile:
-        contents_str = gzipfile.read()
-    dicts = [json.loads(c) for c in contents_str.splitlines()]
-    df = pd.DataFrame.from_records(dicts)
+        contents_str = gzipfile.read().decode("utf-8")
+
+    records = []
+    for line in contents_str.splitlines():
+        if not line.strip():
+            continue  # Ignore empty lines. On 2025/02/26 a file mysteriously had an empty line between records.
+        try:
+            record = json.loads(line)
+            records.append(record)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Invalid JSON in blob {key}: {line[:100]}... Error: {e}")
+
+    df = pd.DataFrame.from_records(records)
     df.rename(columns={"article": "html"}, inplace=True)
     df["text"] = [
         handle_html2text(html, key, resolved_id)
@@ -262,7 +272,6 @@ def transform(
         hashlib.md5(t.encode("utf-8")).hexdigest() if t else None for t in df["text"]
     ]
     return df
-
 
 # combined the stage and stage chunk tasks into new one
 # also removed the get_stage_prefix function in favor of setting in the flow

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -273,6 +273,7 @@ def transform(
     ]
     return df
 
+
 # combined the stage and stage chunk tasks into new one
 # also removed the get_stage_prefix function in favor of setting in the flow
 @task()

--- a/data-products/tests/article_text_streaming/unit/test_article_text_streaming_flow.py
+++ b/data-products/tests/article_text_streaming/unit/test_article_text_streaming_flow.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock
 
 import boto3
 import pytest
+
 from article_text_streaming.article_text_streaming_flow import (
     FAILURES_FILE_PATH,
     S3_BUCKET,
@@ -18,11 +19,13 @@ from article_text_streaming.article_text_streaming_flow import (
     create_chunks,
     etl,
     main,
+    transform,
 )
 from common import get_script_path
 from common.settings import CommonSettings
 from moto import mock_s3
 from prefect import flow, get_run_logger, task
+from prefect.logging import disable_run_logger
 from prefect_aws import AwsCredentials
 
 CS = CommonSettings()  # type: ignore
@@ -195,6 +198,77 @@ def test_main(monkeypatch, range_end):
             run(main())
             test_text = FAILURES_FILE_PATH.read_text()
             assert len(test_text.splitlines()) == range_end - 1
+
+
+def test_transform_ignores_invalid_json(tmp_path, monkeypatch, caplog):
+    """Test that invalid JSON is logged as a warning and that the task continues processing."""
+    # Create a valid JSON record
+    valid_record = {"resolved_id": "1466307989", "article": "<!--VIDEO_1-->"}
+    # Create an invalid JSON record that contains an unexpected newline
+    invalid_record = '{"resolved_id":"1946438721","article":"<!--IMG_1--><div>\nInvalid newline</div>"}'
+
+    # Combine them (order: valid then invalid)
+    combined = json.dumps(valid_record) + "\n" + invalid_record
+    gz_fileobj = write_gzip_data(combined)
+    gzipped_content = gz_fileobj.getvalue()
+
+    # Patch get_text_from_html to simply return the HTML unchanged.
+    monkeypatch.setattr(
+        "article_text_streaming.article_text_streaming_flow.get_text_from_html",
+        lambda html: html
+    )
+
+    # Use a temporary file for the failures store
+    failures_file = tmp_path / "failures.json"
+
+    # Disable the Prefect run logger context to avoid MissingContextError.
+    with disable_run_logger():
+        # Call the transform function (since it's a Prefect task, use .fn to call synchronously)
+        df = transform.fn(gzipped_content, "dummy_key", 0, failures_file)
+
+    # Check that the resulting dataframe only has the valid record.
+    # (Since our combined blob had 2 lines, one valid and one invalid)
+    assert len(df) == 1
+    assert df["resolved_id"].iloc[0] == "1466307989"
+
+    # Verify that a warning about invalid JSON was logged.
+    # caplog captures logs; we check that a warning message appears.
+    assert any("Invalid JSON in blob dummy_key" in record.message for record in caplog.records)
+
+
+def test_transform_with_empty_lines_between_records(tmp_path, monkeypatch, caplog):
+    """
+    Test that extra empty lines between records are ignored, which occurred in
+    article/streaming-html/2025/02/26/01/KDS-S3-56bBp-4-2025-02-26-01-56-30-2725e0de-621a-4d3a-a45a-dfcd5991b782.gz
+    """
+    # Create two valid JSON records.
+    record1 = {"resolved_id": "100", "article": "<!--VIDEO_1-->"}
+    record2 = {"resolved_id": "101", "article": "<!--VIDEO_2-->"}
+
+    combined = json.dumps(record1) + "\n" + "\n" + json.dumps(record2)
+    gz_fileobj = write_gzip_data(combined)
+    gzipped_content = gz_fileobj.getvalue()
+
+    # Patch get_text_from_html to simply return the HTML unchanged.
+    monkeypatch.setattr(
+        "article_text_streaming.article_text_streaming_flow.get_text_from_html",
+        lambda html: html
+    )
+
+    # Use a temporary file for the failures store.
+    failures_file = tmp_path / "failures.json"
+
+    # Disable the Prefect run logger context to avoid MissingContextError.
+    with disable_run_logger():
+        df = transform.fn(gzipped_content, "dummy_key", 0, failures_file)
+
+    # Verify that the resulting DataFrame has both records.
+    assert len(df) == 2
+    assert df["resolved_id"].iloc[0] == "100"
+    assert df["resolved_id"].iloc[1] == "101"
+
+    # Confirm that no warning about invalid JSON was logged.
+    assert not any("Invalid JSON in blob dummy_key" in record.message for record in caplog.records)
 
 
 def test_create_chunks_exception():

--- a/data-products/tests/article_text_streaming/unit/test_article_text_streaming_flow.py
+++ b/data-products/tests/article_text_streaming/unit/test_article_text_streaming_flow.py
@@ -215,7 +215,7 @@ def test_transform_ignores_invalid_json(tmp_path, monkeypatch, caplog):
     # Patch get_text_from_html to simply return the HTML unchanged.
     monkeypatch.setattr(
         "article_text_streaming.article_text_streaming_flow.get_text_from_html",
-        lambda html: html
+        lambda html: html,
     )
 
     # Use a temporary file for the failures store
@@ -233,7 +233,9 @@ def test_transform_ignores_invalid_json(tmp_path, monkeypatch, caplog):
 
     # Verify that a warning about invalid JSON was logged.
     # caplog captures logs; we check that a warning message appears.
-    assert any("Invalid JSON in blob dummy_key" in record.message for record in caplog.records)
+    assert any(
+        "Invalid JSON in blob dummy_key" in record.message for record in caplog.records
+    )
 
 
 def test_transform_with_empty_lines_between_records(tmp_path, monkeypatch, caplog):
@@ -252,7 +254,7 @@ def test_transform_with_empty_lines_between_records(tmp_path, monkeypatch, caplo
     # Patch get_text_from_html to simply return the HTML unchanged.
     monkeypatch.setattr(
         "article_text_streaming.article_text_streaming_flow.get_text_from_html",
-        lambda html: html
+        lambda html: html,
     )
 
     # Use a temporary file for the failures store.
@@ -268,7 +270,9 @@ def test_transform_with_empty_lines_between_records(tmp_path, monkeypatch, caplo
     assert df["resolved_id"].iloc[1] == "101"
 
     # Confirm that no warning about invalid JSON was logged.
-    assert not any("Invalid JSON in blob dummy_key" in record.message for record in caplog.records)
+    assert not any(
+        "Invalid JSON in blob dummy_key" in record.message for record in caplog.records
+    )
 
 
 def test_create_chunks_exception():


### PR DESCRIPTION
## Goal
[MC-1681](https://mozilla-hub.atlassian.net/browse/MC-1681) Fix [data-products.article-text-streaming.main](https://app.prefect.cloud/account/20e6b12d-ffc1-4de6-b27b-c38b0bbe68f7/workspace/9ca53df3-2b17-44a6-a7d2-bdcc9d29e09c/flows/flow/910c412b-7645-41e9-b5a8-3275ef328441) failing due to unexpected newlines between JSON records:

```
{"resolved_id":"1946438721","article":"<!--IMG_1--><div nodeIndex=\"77\"><div nodeIndex=\"79\"><p nodeIndex=\"80\">When it comes to dinner parties, the conversation is one thing that can&rsquo;t be set up in advance. But that doesn&rsquo;t mean you can&rsquo;t be prepared. With the holiday season imminent, we asked Rico Gagliano and Brendan Francis Newnam, hosts of the podcast &ldquo;<a href=\"https:\/\/www.dinnerpartydownload.org\/\" title=\"\" rel=\"noopener noreferrer\" target=\"_blank\" nodeIndex=\"354\">The Dinner Party Download<\/a>,&rdquo; for some dos and don&rsquo;ts on how to spark memorable conversation during your dinner party.<\/p><p nodeIndex=\"81\">These tips are part of the magazine&rsquo;s latest food issue all about <a href=\"https:\/\/www.nytimes.com\/interactive\/2017\/10\/25\/magazine\/food-issue-art-of-dinner-party.html\" title=\"\" nodeIndex=\"355\">the art of the dinner party<\/a>. Check it out for more inspiration and recipes to help you host your own dinner parties this season.<\/p><h2 nodeIndex=\"82\">Warm Up the Crowd<\/h2><p nodeIndex=\"83\">Small talk gives guests a chance to get to know one another, and to take one another&rsquo;s measure, before the conversation turns to weightier matters &mdash; e.g., sex, the lonely meaninglessness of existence and Trump&rsquo;s latest tweet. It&rsquo;s like stretching before a jog.<\/p><h2 nodeIndex=\"84\">Be a Conversation Conduit<\/h2><p nodeIndex=\"85\">Don&rsquo;t leave some guests nodding their heads and pretending they know what&rsquo;s going on. Often, clarification is required. If a guest is mumbling, restate a phrase for people who couldn&rsquo;t hear what was said. If a guest makes an inside joke, go ahead and laugh &mdash; and then put it in context for everyone.<\/p><\/div><aside aria-label=\"companion column\" nodeIndex=\"356\"><\/aside><\/div><div nodeIndex=\"87\"><div nodeIndex=\"88\"><h2 nodeIndex=\"89\">Less Talking, More Listening<\/h2><p nodeIndex=\"90\">The sad truth is, no one cares what you have to say; they care about what <em nodeIndex=\"357\">they<\/em> have to say. Deep down, people want to feel they&rsquo;ve been heard. They will if you let them talk.<\/p><\/div><aside aria-label=\"companion column\" nodeIndex=\"358\"><\/aside><\/div><a href=\"https:\/\/www.nytimes.com\/interactive\/2017\/10\/25\/magazine\/food-issue-samin-nosrat-hands-on-dumpling-party.html\">Samin Nosrat&rsquo;s dinner party<\/a><div nodeIndex=\"97\"><div nodeIndex=\"98\"><h2 nodeIndex=\"99\">Embrace Complicated Topics<\/h2><p nodeIndex=\"100\">We all know what society says we&rsquo;re not supposed to talk about at a dinner party. Religion. Politics. Salaries. And yet these topics should be fair game. What&rsquo;s a dinner party if not a laboratory of ideas, plus permission to eat cheese?<\/p><h2 nodeIndex=\"101\">Provocation With Style<\/h2><p nodeIndex=\"102\">Don&rsquo;t worry about dangerous conversational territory. The most memorable conversations are a product of guests who dare to provoke, titillate and argue. The trick is to create a permissive atmosphere with civility and style. The goal, Elaine Stritch once told us, is to be a &ldquo;ladylike broad&rdquo;: half civilized charmer, half wisecracking bomb-thrower.<\/p><h2 nodeIndex=\"103\">Keep Arguments Low-Key<\/h2><p nodeIndex=\"104\">A single conversation will not convince a lifelong liberal that it&rsquo;s O.K. to own an arsenal of assault rifles. The perfect retort will not convince a conservative that we should be taxed to fund performance art. Accept this. It&rsquo;s amazing how much more relaxed a political argument becomes when you understand that you don&rsquo;t have to &mdash; and in fact won&rsquo;t &mdash; &ldquo;win.&rdquo;<\/p><\/div><aside aria-label=\"companion column\" nodeIndex=\"359\"><\/aside><\/div><div nodeIndex=\"106\"><div nodeIndex=\"107\"><h2 nodeIndex=\"108\">Personalize Your Politics<\/h2><p nodeIndex=\"109\">Go for empathy when you talk politics. Showing how a political issue affects you intimately is more important than data and statistics. Try leading with a personal story.<\/p><h2 nodeIndex=\"110\">The Two W&rsquo;s: What and Why<\/h2><p nodeIndex=\"111\">To ensure that a guest&rsquo;s story becomes truly interesting, just ask two questions over and over: what and why. What exactly happened? What did that feel like? Seek emotional specifics. And then: Why? Why is this anecdote important? This is where the guest&rsquo;s most thoughtful connection to a story lies.<\/p><h2 nodeIndex=\"112\">Venture Into the Unconventional<\/h2><p nodeIndex=\"113\">Small talk need not be soporific. Before the dinner party, try to find some recent news items or weird science stories that people most likely haven&rsquo;t heard about. Did you know that music is beneficial to cats undergoing surgery? Or that there is a library in Norway that is amassing 100 never-before-read books that no one can check out for 100 years?<\/p><h2 nodeIndex=\"114\">Don&rsquo;t Assume<\/h2><p nodeIndex=\"115\">Asking questions can get a guest to reveal something fascinating about herself. But a quick way to prevent that is to give her possible answers. &ldquo;Why did you quit law school &mdash; <em nodeIndex=\"360\">was it too boring?<\/em>&rdquo; Leave out the guess. A short question is more likely to provoke details.<\/p><\/div><aside aria-label=\"companion column\" nodeIndex=\"361\"><\/aside><\/div>"}

{"resolved_id":"1466307989","article":"<!--VIDEO_1-->"}
```

This empty line throws an unhandled exception when the task tries to decode it as JSON:

> Traceback (most recent call last):
>   File "/usr/local/lib/python3.10/site-packages/prefect/engine.py", line 2103, in orchestrate_task_run
>     result = await call.aresult()
>   File "/usr/local/lib/python3.10/site-packages/prefect/_internal/concurrency/calls.py", line 327, in aresult
>     return await asyncio.wrap_future(self.future)
>   File "/usr/local/lib/python3.10/site-packages/prefect/_internal/concurrency/calls.py", line 352, in _run_sync
>     result = self.fn(*self.args, **self.kwargs)
>   File "/opt/prefect/data-products/src/article_text_streaming/article_text_streaming_flow.py", line 254, in transform
>     dicts = [json.loads(c) for c in contents_str.splitlines()]
>   File "/opt/prefect/data-products/src/article_text_streaming/article_text_streaming_flow.py", line 254, in <listcomp>
>     dicts = [json.loads(c) for c in contents_str.splitlines()]
>   File "/usr/local/lib/python3.10/json/__init__.py", line 346, in loads
>     return _default_decoder.decode(s)
>   File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode
>     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
>   File "/usr/local/lib/python3.10/json/decoder.py", line 355, in raw_decode
>     raise JSONDecodeError("Expecting value", s, err.value) from None
> json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
> 05:02:52 PM
> Error
> Finished in state Failed('Task run encountered an exception JSONDecodeError: Expecting value: line 1 column 1 (char 0)')

## Implementation Decisions
I did not investigate why the source data was invalid. I believe these originate from Pocket's parser, and undergo some processing somewhere. 

## References

[Slack thread](https://mozilla.slack.com/archives/C05UHBNS1HV/p1741120276331179)

[MC-1681]: https://mozilla-hub.atlassian.net/browse/MC-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ