### PR TITLE
AD-624 Add billboard and leaderboard uapi interactions to Mode SPOC reports

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.15.17"
+version = "0.15.18"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/firefox_newtab/sql/uapi_interactions_hourly/uapi_daily_interactions_by_tile_id_position/data.sql
+++ b/data-products/src/firefox_newtab/sql/uapi_interactions_hourly/uapi_daily_interactions_by_tile_id_position/data.sql
@@ -14,7 +14,12 @@ WHERE
   submission_hour >= '{{ batch_start }}'
   AND submission_hour < '{{ batch_end }}'
   AND form_factor = 'desktop'
-  AND placement IN ('newtab_spocs', 'newtab_rectangle', 'newtab_billboard', 'newtab_leaderboard')
+  AND placement IN (
+    'newtab_spocs',
+    'newtab_rectangle',
+    'newtab_billboard',
+    'newtab_leaderboard'
+  )
 GROUP BY
   happened_at,
   ad_id,

--- a/data-products/src/firefox_newtab/sql/uapi_interactions_hourly/uapi_daily_interactions_by_tile_id_position/data.sql
+++ b/data-products/src/firefox_newtab/sql/uapi_interactions_hourly/uapi_daily_interactions_by_tile_id_position/data.sql
@@ -14,7 +14,7 @@ WHERE
   submission_hour >= '{{ batch_start }}'
   AND submission_hour < '{{ batch_end }}'
   AND form_factor = 'desktop'
-  AND placement IN ('newtab_spocs', 'newtab_rectangle')
+  AND placement IN ('newtab_spocs', 'newtab_rectangle', 'newtab_billboard', 'newtab_leaderboard')
 GROUP BY
   happened_at,
   ad_id,


### PR DESCRIPTION
## Goal
What changed? What is the business/product goal?

Add billboard and leaderboard interactions to the data that is pulled into Snowflake for Mode SPOC reporting.

## Implementation Decisions
 

## Deployment steps
- This [private-bigquery-etl PR](https://github.com/mozilla/private-bigquery-etl/pull/584) also needs to be merged, and that table backfilled
- After deploying this change, we backfill this dataflow job for those same days
- After backfilling the dataflow job, we also backfill the Snowflake model

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/AD-624

Documentation:

