### PR TITLE
Fix article streaming crash

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.15.18"
+version = "0.15.19"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -490,7 +490,7 @@ FLOW_SPEC = FlowSpec(
             job_variables={
                 "ephemeralStorage": {"sizeInGiB": 200},
                 "cpu": 4096,
-                "memory": 8192,
+                "memory": 30720,
                 "env": {
                     "ARTICLE_DB": CS.deployment_type_value(
                         dev="development", staging="development", main="raw"


### PR DESCRIPTION
## Goal
Prevent this task from running out of memory.

![image](https://github.com/user-attachments/assets/b2ba8728-d5c1-4323-9c8b-1cd6059d2012)

The above chart shows the average for 2 tasks on this cluster, so the actual memory usage is probably approaching 100% for this task after 30 minutes.

## Implementation Decisions
- I could not find how to enable 'Container Insights with enhanced observability' in CDKTF, to observe memory for a single task, so I'm leaving it out of this PR.
- I haven't yet looked at how much work the task is trying to do. It's been failing for a long time, so possibly it has a big backlog. If so, increasing memory might not be sufficient.

## References

[Slack thread](https://mozilla.slack.com/archives/C05UHBNS1HV/p1741905336956469?thread_ts=1741120276.331179&cid=C05UHBNS1HV)
