### PR TITLE
fix: streaming-articles 404 error for missing files on s3

### DIFF
--- a/data-products/pyproject.toml
+++ b/data-products/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-products"
-version = "0.15.19"
+version = "0.15.20"
 description = "Main project folder for data products prefect flows"
 authors = ["Braun <breyes@mozilla.com>"]
 license = "Apache-2.0"

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -315,7 +315,10 @@ def cleanup(key: str, aws_creds: AwsCredentials):
     try:
         s3_client.delete_object(Bucket=S3_BUCKET, Key=key)
     except botocore.exceptions.ClientError as e:
-        logger.warning(f"Failed to delete key {key}. Skipping file. {e}")
+        if e.response.get("Error", {}).get("Code") == "404":
+            logger.warning(f"File not found during cleanup: {key}. Skipping deletion.")
+        else:
+            raise
 
 
 @flow(task_runner=DaskTaskRunner())
@@ -344,7 +347,10 @@ async def etl(
             result = await job.result()
             extract_results.append((result, key))
         except botocore.exceptions.ClientError as e:
-            logger.warning(f"Failed to download key {key}. Skipping file. {e}")
+            if e.response.get("Error", {}).get("Code") == "404":
+                logger.warning(f"File not found for key {key}. Skipping file.")
+            else:
+                raise
     # init list for collecting task results
     transform_jobs = []
     # submit transform for each fileobj

--- a/data-products/src/article_text_streaming/article_text_streaming_flow.py
+++ b/data-products/src/article_text_streaming/article_text_streaming_flow.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import pandas as pd
 import pendulum as pdm
+import botocore.exceptions
 from common.databases.snowflake_utils import MozSnowflakeConnector
 from common.deployment.worker import FlowDeployment, FlowSpec
 from common.settings import CommonSettings
@@ -311,7 +312,10 @@ def cleanup(key: str, aws_creds: AwsCredentials):
     logger = get_run_logger()
     logger.info(f"deleting file: {key}")
     s3_client = aws_creds.get_s3_client()
-    s3_client.delete_object(Bucket=S3_BUCKET, Key=key)
+    try:
+        s3_client.delete_object(Bucket=S3_BUCKET, Key=key)
+    except botocore.exceptions.ClientError as e:
+        logger.warning(f"Failed to delete key {key}. Skipping file. {e}")
 
 
 @flow(task_runner=DaskTaskRunner())
@@ -334,7 +338,13 @@ async def etl(
             )
         )
     # collect downloaded fileobjs
-    extract_results = [(await job.result(), key) for job, key in extract_jobs]
+    extract_results = []
+    for job, key in extract_jobs:
+        try:
+            result = await job.result()
+            extract_results.append((result, key))
+        except botocore.exceptions.ClientError as e:
+            logger.warning(f"Failed to download key {key}. Skipping file. {e}")
     # init list for collecting task results
     transform_jobs = []
     # submit transform for each fileobj


### PR DESCRIPTION
## Goal
Continue processing streaming article data, even when some files are no longer found on s3:

> botocore.exceptions.ClientError: An error occurred (404) when calling the HeadObject operation: Not Found

It's not exactly clear to me why files disappear after the start of the flow. Our first thought was that multiple flows are stepping on each other, but even with no concurrently running flows, [this still happens](https://app.prefect.cloud/account/20e6b12d-ffc1-4de6-b27b-c38b0bbe68f7/workspace/9ca53df3-2b17-44a6-a7d2-bdcc9d29e09c/runs/flow-run/0085754f-3884-4f79-aa60-7d80034ee957?entity_id=d3099cc9-7bfb-4dfc-b7bc-81372f64b3eb).

## Implementation Decisions
Catching all ClientErrors instead of only 404s for simplicity. 

## References

[Slack thread](https://mozilla.slack.com/archives/C05UHBNS1HV/p1741120276331179)